### PR TITLE
Add skip and finish options to CLI

### DIFF
--- a/builder/src/cli/constants.ts
+++ b/builder/src/cli/constants.ts
@@ -1,0 +1,2 @@
+export const SKIP = "skip";
+export const FINISH = "finish";

--- a/builder/src/cli/getLanguage.ts
+++ b/builder/src/cli/getLanguage.ts
@@ -1,6 +1,7 @@
 import { select } from "@inquirer/prompts";
 import { readdir } from "fs/promises";
 import { basename, extname } from "path";
+import { FINISH, SKIP } from "./constants";
 
 export const getLanguage = async () => {
   const options = await (
@@ -10,9 +11,13 @@ export const getLanguage = async () => {
   return select({
     message: "Programming languages of the project?",
     default: "typescript",
-    choices: options.map((lang) => ({
-      name: lang,
-      value: lang.toLowerCase(),
-    })),
+    choices: [
+      { name: "Skip", value: SKIP },
+      { name: "Finish", value: FINISH },
+      ...options.map((lang) => ({
+        name: lang,
+        value: lang.toLowerCase(),
+      })),
+    ],
   });
 };

--- a/builder/src/cli/main.ts
+++ b/builder/src/cli/main.ts
@@ -6,6 +6,7 @@ import { writeFile } from "fs/promises";
 import { builder } from "../builder";
 import { getLanguage } from "./getLanguage";
 import { outputPath } from "./outputPath";
+import { FINISH, SKIP } from "./constants";
 
 // export async function projectType() {
 //   return inquirer.prompt([
@@ -26,11 +27,31 @@ import { outputPath } from "./outputPath";
 //   ]);
 // }
 
+const generateFile = async (options: Record<string, unknown>, path?: string) => {
+  const mdFile = await builder(options);
+  const output = path ?? process.cwd();
+  await writeFile(`${output}/Agents.md`, mdFile, "utf-8");
+};
+
 export const main = async () => {
+  const options: Record<string, unknown> = {};
+
   const language = await getLanguage();
-  const mdFile = await builder({ language });
-  const path = await outputPath();
-  await writeFile(`${path}/Agents.md`, mdFile, "utf-8");
+  if (language === FINISH) {
+    await generateFile(options);
+    return;
+  }
+  if (language !== SKIP) {
+    options.language = language;
+  }
+
+  const pathAnswer = await outputPath();
+  if (pathAnswer === FINISH) {
+    await generateFile(options);
+    return;
+  }
+  const path = pathAnswer === SKIP ? undefined : pathAnswer;
+  await generateFile(options, path);
 };
 
 (async () => {

--- a/builder/src/cli/outputPath.ts
+++ b/builder/src/cli/outputPath.ts
@@ -1,17 +1,26 @@
 import { input, select } from "@inquirer/prompts";
 import { cwd } from "process";
+import { FINISH, SKIP } from "./constants";
 
-export const outputPath = async () => {
+export const outputPath = async (): Promise<string | typeof SKIP | typeof FINISH> => {
   const specificPath = await select({
     message: "Do you want to output the file to a specific path?",
     choices: [
-      { value: true, name: "Specific path" },
-      { value: false, name: "Default path" },
+      { value: "specific", name: "Specific path" },
+      { value: "default", name: "Default path" },
+      { value: SKIP, name: "Skip" },
+      { value: FINISH, name: "Finish" },
     ],
   });
-  if (specificPath === false) {
-    return cwd();
+
+  if (specificPath === FINISH) {
+    return FINISH;
   }
+
+  if (specificPath === SKIP || specificPath === "default") {
+    return SKIP;
+  }
+
   const path = await input({
     message: "Enter the output path",
     default: cwd(),


### PR DESCRIPTION
## Summary
- add constants for `SKIP` and `FINISH`
- update `getLanguage` prompt to include skip/finish options
- update `outputPath` prompt to include skip/finish options
- enhance `main` flow to handle skipping and finishing early

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f1e69d05c8332bf3e443e6873dc0f