### PR TITLE
Publishable builder package

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -1,0 +1,4 @@
+# @vibe-code/builder
+
+Generate a consolidated `Agents.md` file from multiple prompt templates. Use it programmatically or through the included CLI.
+

--- a/builder/package.json
+++ b/builder/package.json
@@ -1,5 +1,20 @@
 {
   "name": "@vibe-code/builder",
+  "version": "0.1.0",
+  "description": "Generate Vibe coding agent instructions",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "vibe-builder": "dist/cli/main.js"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vibe-code/vibe-coding.git"
+  },
   "scripts": {
     "build": "tsc",
     "prebuild": "rimraf dist",

--- a/builder/src/builder/general/generalSegment.ts
+++ b/builder/src/builder/general/generalSegment.ts
@@ -1,7 +1,11 @@
 import { readFile } from "fs/promises";
 import { join } from "path";
 
-export const generalSegment = async (templatesPath: string) => {
+import { RootContent } from "mdast";
+
+export const generalSegment = async (
+  templatesPath: string
+): Promise<RootContent[]> => {
   const generalJsonFile = (
     await readFile(join(templatesPath, "general.json"), {
       encoding: "utf-8",
@@ -9,7 +13,7 @@ export const generalSegment = async (templatesPath: string) => {
   ).toString();
   const generalItems = JSON.parse(generalJsonFile);
 
-  const generalSegment = [
+  const generalSegment: RootContent[] = [
     {
       type: "heading",
       depth: 2,

--- a/builder/src/builder/language/languageSegment.ts
+++ b/builder/src/builder/language/languageSegment.ts
@@ -1,11 +1,12 @@
 import { readFile } from "fs/promises";
 import { join } from "path";
 import { Languages } from "./options";
+import { RootContent } from "mdast";
 
 export const languageSegment = async (
   templatesPath: string,
   language: string
-) => {
+): Promise<RootContent[]> => {
   const languageJsonFile = (
     await readFile(join(templatesPath, "language", `${language}.json`), {
       encoding: "utf-8",
@@ -42,7 +43,7 @@ export const languageSegment = async (
     }
   }
 
-  const languageSegment = [
+  const languageSegment: RootContent[] = [
     {
       type: "heading",
       depth: 2,

--- a/builder/src/builder/project/projectSegment.ts
+++ b/builder/src/builder/project/projectSegment.ts
@@ -1,10 +1,11 @@
 import { readFile } from "fs/promises";
 import { join } from "path";
+import type { RootContent } from "mdast";
 
 export const projectSegment = async (
   templatesPath: string,
   projectType: string
-) => {
+): Promise<RootContent[]> => {
   const projectJsonFile = (
     await readFile(join(templatesPath, "project", `${projectType}.json`), {
       encoding: "utf-8",
@@ -12,7 +13,7 @@ export const projectSegment = async (
   ).toString();
   const projectItems = JSON.parse(projectJsonFile);
 
-  const projectSegment = [
+  const projectSegment: RootContent[] = [
     {
       type: "heading",
       depth: 2,

--- a/builder/src/index.ts
+++ b/builder/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./builder";
+export * from "./cli";

--- a/builder/tsconfig.json
+++ b/builder/tsconfig.json
@@ -13,7 +13,7 @@
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
-    // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                         /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                           /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */


### PR DESCRIPTION
## Summary
- prepare the builder for publishing
- provide README for the builder
- add `index.ts` entry point
- type returned segments for clarity
- generate type declarations

## Testing
- `npx vitest run`
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_684f5969a70c83329bc36b5872861690