### PR TITLE
Fix CLI packaging

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -2,7 +2,10 @@
   "name": "@vibe-builder/cli",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "prebuild": "rimraf dist"

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { writeFile } from "fs/promises";
 import { builder, BuilderOptions } from "@vibe-builder/builder";
 import { getLanguage } from "./getLanguage";


### PR DESCRIPTION
## Summary
- add a shebang in the CLI entry
- point `main` to `dist/index.js`
- publish only the compiled files

## Testing
- `pnpm test` in `builder`
- `pnpm build` in `cli`


------
https://chatgpt.com/codex/tasks/task_e_684f70902ec88332b01bdb3e2a5a0554