### PR TITLE
Convert general json to typed rules

### DIFF
--- a/builder/src/builder.ts
+++ b/builder/src/builder.ts
@@ -20,7 +20,7 @@ export async function builder(options?: BuilderOptions): Promise<string> {
   };
   const templatesPath = join(__dirname, "../templates");
 
-  tree.children = tree.children.concat(await generalSegment(templatesPath));
+  tree.children = tree.children.concat(await generalSegment());
   if (options === undefined) {
     return toMarkdown(tree);
   }

--- a/builder/src/general/__snapshots__/generalSegment.spec.ts.snap
+++ b/builder/src/general/__snapshots__/generalSegment.spec.ts.snap
@@ -1,0 +1,79 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`generalSegment > returns general guidelines 1`] = `
+[
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "General Guidelines",
+      },
+    ],
+    "depth": 2,
+    "type": "heading",
+  },
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "Don't work on any of the tasks in the TODO.md file unless you are asked to.",
+      },
+    ],
+    "type": "listItem",
+  },
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "Always try to early return from functions.",
+      },
+    ],
+    "type": "listItem",
+  },
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "Use \`const\` for variables that are not reassigned.",
+      },
+    ],
+    "type": "listItem",
+  },
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "Make sure to focus on why and not how in documentation.",
+      },
+    ],
+    "type": "listItem",
+  },
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "Write predictable functions and make a spec file for them according to the testing library in use.",
+      },
+    ],
+    "type": "listItem",
+  },
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "Don't use \`any\` in TypeScript, use \`unknown\` instead.",
+      },
+    ],
+    "type": "listItem",
+  },
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "Don't cast types without validation.",
+      },
+    ],
+    "type": "listItem",
+  },
+]
+`;

--- a/builder/src/general/generalSegment.spec.ts
+++ b/builder/src/general/generalSegment.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "vitest";
+import { generalSegment } from "./generalSegment";
+
+describe("generalSegment", () => {
+  test("returns general guidelines", async () => {
+    const segment = await generalSegment();
+    expect(segment).toMatchSnapshot();
+  });
+});

--- a/builder/src/general/generalSegment.ts
+++ b/builder/src/general/generalSegment.ts
@@ -1,28 +1,21 @@
-import { readFile } from "fs/promises";
-import { join } from "path";
+import type { ListItem, RootContent } from "mdast";
+import { generalRules } from "./rules";
 
-import { RootContent } from "mdast";
+export const generalSegment = async (): Promise<RootContent[]> => {
+  const generalItems = generalRules;
 
-export const generalSegment = async (
-  templatesPath: string
-): Promise<RootContent[]> => {
-  const generalJsonFile = (
-    await readFile(join(templatesPath, "general.json"), {
-      encoding: "utf-8",
-    })
-  ).toString();
-  const generalItems = JSON.parse(generalJsonFile);
-
-  const generalSegment: RootContent[] = [
+  const segment: RootContent[] = [
     {
       type: "heading",
       depth: 2,
       children: [{ type: "text", value: "General Guidelines" }],
     },
-    ...generalItems.map((item: string) => ({
-      type: "listItem",
-      children: [{ type: "text", value: item }],
-    })),
+    ...generalItems.map(
+      (item): ListItem => ({
+        type: "listItem",
+        children: [{ type: "text", value: item }],
+      })
+    ),
   ];
-  return generalSegment;
+  return segment;
 };

--- a/builder/src/general/rules.ts
+++ b/builder/src/general/rules.ts
@@ -1,4 +1,4 @@
-[
+export const generalRules = [
   "Don't work on any of the tasks in the TODO.md file unless you are asked to.",
   "Always try to early return from functions.",
   "Use `const` for variables that are not reassigned.",
@@ -6,4 +6,6 @@
   "Write predictable functions and make a spec file for them according to the testing library in use.",
   "Don't use `any` in TypeScript, use `unknown` instead.",
   "Don't cast types without validation."
-]
+] as const;
+
+export type GeneralRule = (typeof generalRules)[number];


### PR DESCRIPTION
## Summary
- replace `general.json` with a typed `rules.ts`
- update general segment implementation
- adjust builder to use updated segment
- add tests for the general segment

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684ffbe5d22c8332862d84194f251f4e