### PR TITLE
Add builder CI workflow

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -1,0 +1,34 @@
+name: Builder CI/CD
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint-build-publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: builder
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10.12.1
+      - name: Install dependencies
+        run: pnpm install
+      - name: Lint
+        run: pnpm run lint
+      - name: Build
+        run: pnpm run build
+      - name: Publish
+        run: pnpm publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/builder/package.json
+++ b/builder/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "lint": "tsc --noEmit",
     "prebuild": "rimraf dist",
     "build:w": "tsc --watch",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- add `lint` script to builder package
- add GitHub Actions workflow to lint, build and publish builder on main branch merges

## Testing
- `pnpm run lint` *(fails: error TS2322 in generalSegment.ts)*

------
https://chatgpt.com/codex/tasks/task_e_684ffd6e35b08332aa925ab516ac29cb