### PR TITLE
Convert template JSON rules to TS modules

### DIFF
--- a/builder/src/builder.ts
+++ b/builder/src/builder.ts
@@ -1,6 +1,5 @@
 import { Root } from "mdast";
 import { toMarkdown } from "mdast-util-to-markdown";
-import { join } from "path";
 import { generalSegment } from "./general/generalSegment";
 import { languageSegment } from "./language/languageSegment";
 import { projectSegment } from "./project/projectSegment";
@@ -18,8 +17,6 @@ export async function builder(options?: BuilderOptions): Promise<string> {
       },
     ],
   };
-  const templatesPath = join(__dirname, "../templates");
-
   tree.children = tree.children.concat(await generalSegment());
   if (options === undefined) {
     return toMarkdown(tree);
@@ -39,19 +36,19 @@ export async function builder(options?: BuilderOptions): Promise<string> {
 
   if (language) {
     tree.children = tree.children.concat(
-      await languageSegment(templatesPath, language)
+      await languageSegment("", language)
     );
   }
 
   if (projectType) {
     tree.children = tree.children.concat(
-      await projectSegment(templatesPath, projectType)
+      await projectSegment("", projectType)
     );
   }
 
   if (framework) {
     tree.children = tree.children.concat(
-      await frameworkSegment(templatesPath, framework)
+      await frameworkSegment("", framework)
     );
   }
 

--- a/builder/src/framework/frameworkSegment.ts
+++ b/builder/src/framework/frameworkSegment.ts
@@ -1,17 +1,16 @@
-import { readFile } from "fs/promises";
-import { join } from "path";
 import { RootContent } from "mdast";
+import { nestjsRules, reactRules } from "../templates/framework";
 
 export const frameworkSegment = async (
-  templatesPath: string,
+  _templatesPath: string,
   framework: string
 ): Promise<RootContent[]> => {
-  const frameworkJsonFile = (
-    await readFile(join(templatesPath, "framework", `${framework}.json`), {
-      encoding: "utf-8",
-    })
-  ).toString();
-  const frameworkItems = JSON.parse(frameworkJsonFile);
+  const frameworkRulesMap: Record<string, readonly string[]> = {
+    nestjs: nestjsRules,
+    react: reactRules,
+  };
+
+  const frameworkItems = frameworkRulesMap[framework] || [];
 
   const frameworkSegment: RootContent[] = [
     {

--- a/builder/src/templates/framework/index.ts
+++ b/builder/src/templates/framework/index.ts
@@ -1,0 +1,5 @@
+export { nestjsRules } from "./nestjs";
+export { reactRules } from "./react";
+
+export type { NestjsRule } from "./nestjs";
+export type { ReactRule } from "./react";

--- a/builder/src/templates/framework/nestjs.ts
+++ b/builder/src/templates/framework/nestjs.ts
@@ -1,3 +1,5 @@
-[
+export const nestjsRules = [
   "Separate the folder structure into domain driven design (DDD) modules, i.e. each module should have its own folder with controllers, services, and entities."
-]
+] as const;
+
+export type NestjsRule = (typeof nestjsRules)[number];

--- a/builder/src/templates/framework/react.ts
+++ b/builder/src/templates/framework/react.ts
@@ -1,3 +1,5 @@
-[
+export const reactRules = [
   "Use key in React lists to help React identify which items have changed, are added, or removed."
-]
+] as const;
+
+export type ReactRule = (typeof reactRules)[number];

--- a/builder/src/templates/language/index.ts
+++ b/builder/src/templates/language/index.ts
@@ -1,0 +1,5 @@
+export { javascriptRules } from "./javascript";
+export { typescriptRules } from "./typescript";
+
+export type { JavascriptRule } from "./javascript";
+export type { TypescriptRule } from "./typescript";

--- a/builder/src/templates/language/javascript.ts
+++ b/builder/src/templates/language/javascript.ts
@@ -1,6 +1,8 @@
-[
+export const javascriptRules = [
   "Use `const` over `let` unless reassignment is needed.",
   "Use `===` over `==` for strict equality checks.",
   "Use arrow functions for anonymous functions.",
   "Use template literals for string interpolation."
-]
+] as const;
+
+export type JavascriptRule = (typeof javascriptRules)[number];

--- a/builder/src/templates/language/typescript.ts
+++ b/builder/src/templates/language/typescript.ts
@@ -1,0 +1,5 @@
+export const typescriptRules = [
+  "Use Interfaces over Types unless needed."
+] as const;
+
+export type TypescriptRule = (typeof typescriptRules)[number];

--- a/builder/templates/language/typescript.json
+++ b/builder/templates/language/typescript.json
@@ -1,1 +1,0 @@
-["Use Interfaces over Types unless needed."]


### PR DESCRIPTION
## Summary
- move rule templates into `src/templates`
- replace JSON rules with typed modules
- adjust segments to import rule arrays
- update builder to stop referencing template paths

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684ffdb0ee188332b91b82450c2780d7