### PR TITLE
Update builder workflow for PR builds

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   lint-build-publish:
@@ -29,6 +32,7 @@ jobs:
       - name: Build
         run: pnpm run build
       - name: Publish
+        if: github.event_name == 'push'
         run: pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- run builder CI on `pull_request` as well as `push`
- only publish builder package when the workflow runs on `push`

## Testing
- `pnpm lint` *(fails: Type '"text"' is not assignable to type)*
- `pnpm test`
- `pnpm build` *(fails: Type '"text"' is not assignable to type)*
- `pnpm build` in `cli`

------
https://chatgpt.com/codex/tasks/task_e_684ffea48e388332b6aef40526bc3ed0