### PR TITLE
Update builder CD to publish on version bump

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -16,6 +16,8 @@ jobs:
         working-directory: builder
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -31,8 +33,18 @@ jobs:
         run: pnpm run lint
       - name: Build
         run: pnpm run build
+      - name: Check version change
+        id: version
+        run: |
+          prev=$(git show HEAD^:builder/package.json | jq -r '.version')
+          curr=$(jq -r '.version' package.json)
+          if [ "$curr" != "$prev" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Publish
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.version.outputs.changed == 'true'
         run: pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- update the workflow checkout step to fetch history
- check for package.json version changes before publishing

## Testing
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_685000bd28208332a3e56cad3be4e997