### PR TITLE
Convert builder rules to TypeScript

### DIFF
--- a/builder/src/builder.ts
+++ b/builder/src/builder.ts
@@ -1,6 +1,5 @@
 import { Root } from "mdast";
 import { toMarkdown } from "mdast-util-to-markdown";
-import { join } from "path";
 import { generalSegment } from "./general/generalSegment";
 import { languageSegment } from "./language/languageSegment";
 import { projectSegment } from "./project/projectSegment";
@@ -19,8 +18,6 @@ export async function builder(options?: BuilderOptions): Promise<string> {
       },
     ],
   };
-  const templatesPath = join(__dirname, "../templates");
-
   tree.children = tree.children.concat(await generalSegment());
   if (options === undefined) {
     return toMarkdown(tree);
@@ -39,26 +36,18 @@ export async function builder(options?: BuilderOptions): Promise<string> {
   }
 
   if (language) {
-    tree.children = tree.children.concat(
-      await languageSegment(templatesPath, language)
-    );
+    tree.children = tree.children.concat(await languageSegment(language));
     if (lintSystem) {
-      tree.children = tree.children.concat(
-        await lintSegment(templatesPath, lintSystem)
-      );
+      tree.children = tree.children.concat(await lintSegment(lintSystem));
     }
   }
 
   if (projectType) {
-    tree.children = tree.children.concat(
-      await projectSegment(templatesPath, projectType)
-    );
+    tree.children = tree.children.concat(await projectSegment(projectType));
   }
 
   if (framework) {
-    tree.children = tree.children.concat(
-      await frameworkSegment(templatesPath, framework)
-    );
+    tree.children = tree.children.concat(await frameworkSegment(framework));
   }
 
   return toMarkdown(tree);

--- a/builder/src/framework/frameworkSegment.ts
+++ b/builder/src/framework/frameworkSegment.ts
@@ -1,17 +1,16 @@
-import { readFile } from "fs/promises";
-import { join } from "path";
-import { RootContent } from "mdast";
+import type { RootContent } from "mdast";
+import { nestjsRules } from "./nestjs";
+import { reactRules } from "./react";
+
+const frameworkRulesMap: Record<string, readonly string[]> = {
+  nestjs: nestjsRules,
+  react: reactRules,
+};
 
 export const frameworkSegment = async (
-  templatesPath: string,
   framework: string
 ): Promise<RootContent[]> => {
-  const frameworkJsonFile = (
-    await readFile(join(templatesPath, "framework", `${framework}.json`), {
-      encoding: "utf-8",
-    })
-  ).toString();
-  const frameworkItems = JSON.parse(frameworkJsonFile);
+  const frameworkItems = frameworkRulesMap[framework] ?? [];
 
   const frameworkSegment: RootContent[] = [
     {

--- a/builder/src/framework/index.ts
+++ b/builder/src/framework/index.ts
@@ -1,3 +1,5 @@
 export { frameworkSegment } from "./frameworkSegment";
 export { Frameworks, getAvailableFrameworks } from "./options";
 export type { FrameworkOption } from "./options";
+export { nestjsRules } from "./nestjs";
+export { reactRules } from "./react";

--- a/builder/src/framework/nestjs.ts
+++ b/builder/src/framework/nestjs.ts
@@ -1,3 +1,5 @@
-[
+export const nestjsRules = [
   "Separate the folder structure into domain driven design (DDD) modules, i.e. each module should have its own folder with controllers, services, and entities."
-]
+] as const;
+
+export type NestjsRule = (typeof nestjsRules)[number];

--- a/builder/src/framework/react.ts
+++ b/builder/src/framework/react.ts
@@ -1,3 +1,5 @@
-[
+export const reactRules = [
   "Use key in React lists to help React identify which items have changed, are added, or removed."
-]
+] as const;
+
+export type ReactRule = (typeof reactRules)[number];

--- a/builder/src/language/index.ts
+++ b/builder/src/language/index.ts
@@ -1,3 +1,5 @@
 export { Languages } from "./options";
 export type { LanguageName } from "./options";
 export { languageSegment } from "./languageSegment";
+export { javascriptRules } from "./javascript";
+export { typescriptRules } from "./typescript";

--- a/builder/src/language/javascript.ts
+++ b/builder/src/language/javascript.ts
@@ -1,6 +1,8 @@
-[
+export const javascriptRules = [
   "Use `const` over `let` unless reassignment is needed.",
   "Use `===` over `==` for strict equality checks.",
   "Use arrow functions for anonymous functions.",
   "Use template literals for string interpolation."
-]
+] as const;
+
+export type JavascriptRule = (typeof javascriptRules)[number];

--- a/builder/src/language/typescript.ts
+++ b/builder/src/language/typescript.ts
@@ -1,0 +1,5 @@
+export const typescriptRules = [
+  "Use Interfaces over Types unless needed."
+] as const;
+
+export type TypescriptRule = (typeof typescriptRules)[number];

--- a/builder/src/lint/eslint.ts
+++ b/builder/src/lint/eslint.ts
@@ -1,4 +1,6 @@
-[
+export const eslintRules = [
   "Use ESLint to enforce code quality and style guidelines.",
   "Fix lint issues before committing code."
-]
+] as const;
+
+export type EslintRule = (typeof eslintRules)[number];

--- a/builder/src/lint/index.ts
+++ b/builder/src/lint/index.ts
@@ -1,3 +1,4 @@
 export { lintSegment } from "./lintSegment";
 export { LintSystems, getAvailableLintSystems } from "./options";
 export type { LintSystemOption } from "./options";
+export { eslintRules } from "./eslint";

--- a/builder/src/lint/lintSegment.spec.ts
+++ b/builder/src/lint/lintSegment.spec.ts
@@ -1,12 +1,9 @@
 import { describe, expect, test } from "vitest";
 import { lintSegment } from "./lintSegment";
-import { join } from "path";
-
-const templatesPath = join(__dirname, "../../templates");
 
 describe("lintSegment", () => {
   test("returns lint system guidelines", async () => {
-    const segment = await lintSegment(templatesPath, "eslint");
+    const segment = await lintSegment("eslint");
     expect(segment).toMatchSnapshot();
   });
 });

--- a/builder/src/lint/lintSegment.ts
+++ b/builder/src/lint/lintSegment.ts
@@ -1,17 +1,14 @@
-import { readFile } from "fs/promises";
-import { join } from "path";
 import type { ListItem, RootContent } from "mdast";
+import { eslintRules } from "./eslint";
+
+const lintRulesMap: Record<string, readonly string[]> = {
+  eslint: eslintRules,
+};
 
 export const lintSegment = async (
-  templatesPath: string,
   lintSystem: string
 ): Promise<RootContent[]> => {
-  const lintJsonFile = (
-    await readFile(join(templatesPath, "lint", `${lintSystem}.json`), {
-      encoding: "utf-8",
-    })
-  ).toString();
-  const lintItems = JSON.parse(lintJsonFile);
+  const lintItems = lintRulesMap[lintSystem] ?? [];
 
   const segment: RootContent[] = [
     {

--- a/builder/src/project/projectSegment.ts
+++ b/builder/src/project/projectSegment.ts
@@ -12,7 +12,6 @@ const projectRulesMap: Record<string, string[]> = {
 };
 
 export const projectSegment = async (
-  templatesPath: string,
   projectType: string
 ): Promise<RootContent[]> => {
   const projectItems = projectRulesMap[projectType] || [];

--- a/builder/templates/language/typescript.json
+++ b/builder/templates/language/typescript.json
@@ -1,1 +1,0 @@
-["Use Interfaces over Types unless needed."]


### PR DESCRIPTION
## Summary
- move framework, language and lint rules from json to typed constants
- update segments to use new rule constants
- remove templates directory
- adjust vitest for lint segment

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6850053c03a08332b364a62dbb9ff273