### PR TITLE
Fix builder publish path

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -113,6 +113,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Publish
-        run: pnpm publish --no-git-checks
+        run: pnpm --filter ./packages/builder publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- fix path used by CI to publish the builder package
- confirm builder publish workflow via pnpm publish dry-run

## Testing
- `pnpm --filter ./packages/builder lint`
- `pnpm --filter ./packages/builder test`
- `pnpm --filter ./packages/builder publish --dry-run --no-git-checks`

------
https://chatgpt.com/codex/tasks/task_e_68500d44ed288332bdd978ab172d66b4