### PR TITLE
Add release system selection

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,6 @@
 - [x] Move the builder package to a packages folder, don't forget to update the CI/CD pipeline to use the new path.
 
 - [x] Move the cli to an apps folder.
-
-- [ ] When building a lib or any of its subsets, let the user choose also the publishing manager, for example: release-it and semantic-release
+- [x] When building a lib or any of its subsets, let the user choose also the publishing manager, for example: release-it and semantic-release
 
 - [ ] Add option to skip any step of the cli.

--- a/apps/cli/src/getReleaseSystem.ts
+++ b/apps/cli/src/getReleaseSystem.ts
@@ -1,0 +1,13 @@
+import { select } from "@inquirer/prompts";
+import { getAvailableReleaseSystems } from "@vibe-builder/builder";
+
+export const getReleaseSystem = async () => {
+  return select({
+    message: "Which release system would you like to use?",
+    default: "release-it",
+    choices: getAvailableReleaseSystems().map((system) => ({
+      name: system,
+      value: system,
+    })),
+  });
+};

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -7,6 +7,7 @@ import { getFramework } from "./getFramework";
 import { getLintSystem } from "./getLintSystem";
 import { outputPath } from "./outputPath";
 import { getPackageManager } from "./getPackageManager/getPackageManager";
+import { getReleaseSystem } from "./getReleaseSystem";
 
 export const main = async () => {
   let builderOptions: BuilderOptions = {};
@@ -20,6 +21,11 @@ export const main = async () => {
     };
   }
   builderOptions.projectType = await getProjectType();
+
+  if (builderOptions.projectType &&
+      ["lib", "ui-lib"].includes(builderOptions.projectType)) {
+    builderOptions.releaseSystem = await getReleaseSystem();
+  }
 
   // Get framework based on selected project type
   if (builderOptions.projectType) {

--- a/packages/builder/src/BuilderOptions.spec.ts
+++ b/packages/builder/src/BuilderOptions.spec.ts
@@ -36,4 +36,12 @@ describe("BuilderOptions", () => {
       lintSystem: "eslint",
     });
   });
+
+  it("should accept releaseSystem without restrictions", () => {
+    assertType<BuilderOptions>({ releaseSystem: "release-it" });
+    assertType<BuilderOptions>({
+      projectType: "lib",
+      releaseSystem: "semantic-release",
+    });
+  });
 });

--- a/packages/builder/src/BuilderOptions.ts
+++ b/packages/builder/src/BuilderOptions.ts
@@ -1,6 +1,7 @@
 type BaseBuilderOptions = {
   projectType?: string;
   framework?: string;
+  releaseSystem?: string;
 };
 type BuilderOptionsWithLanguage = {
   language: string;

--- a/packages/builder/src/__snapshots__/builder.spec.ts.snap
+++ b/packages/builder/src/__snapshots__/builder.spec.ts.snap
@@ -385,6 +385,51 @@ exports[`builder > working with project type and framework - frontend with react
 "
 `;
 
+exports[`builder > working with project type and release system 1`] = `
+"# AI agent instructions
+
+## General Guidelines
+
+* Don't work on any of the tasks in the TODO.md file unless you are asked to.
+
+* Always try to early return from functions.
+
+* Use \\\`const\\\` for variables that are not reassigned.
+
+* Make sure to focus on why and not how in documentation.
+
+* Write predictable functions and make a spec file for them according to the testing library in use.
+
+* Don't use \\\`any\\\` in TypeScript, use \\\`unknown\\\` instead.
+
+* Don't cast types without validation.
+
+* Whenever finish a task from the TODO.md file mark it as finished, if there is some that already marked as finish delete them
+
+## Project type (lib)
+
+* Work with version control for publish the package if its publishable
+
+* Create a clear and comprehensive README.md with installation instructions, usage examples, and API documentation
+
+* Use semantic versioning (semver) for package versions
+
+* Include proper TypeScript declaration files (.d.ts) for better developer experience
+
+* Set up automated testing with good test coverage before publishing
+
+* Configure proper entry points in package.json (main, module, types fields)
+
+* Consider tree-shaking compatibility by using ES modules
+
+* Add proper keywords and description in package.json for discoverability
+
+## Release system (semantic-release)
+
+* Use semantic-release for automated versioning and changelog generation.
+"
+`;
+
 exports[`builder > working with project type lib 1`] = `
 "# AI agent instructions
 
@@ -549,5 +594,32 @@ exports[`builder > working with project type ui-lib 1`] = `
   &#x20;   \\- \\\`\\<ComponentName>.test.tsx\\\`: Contains tests for the component.
   &#x20;   \\- \\\`\\<ComponentName>.stories.tsx\\\`: Contains Storybook stories for the component.
   \\- \\\`src/index.ts\\\`: Exports all components for easy import.
+"
+`;
+
+exports[`builder > working with release system only 1`] = `
+"# AI agent instructions
+
+## General Guidelines
+
+* Don't work on any of the tasks in the TODO.md file unless you are asked to.
+
+* Always try to early return from functions.
+
+* Use \\\`const\\\` for variables that are not reassigned.
+
+* Make sure to focus on why and not how in documentation.
+
+* Write predictable functions and make a spec file for them according to the testing library in use.
+
+* Don't use \\\`any\\\` in TypeScript, use \\\`unknown\\\` instead.
+
+* Don't cast types without validation.
+
+* Whenever finish a task from the TODO.md file mark it as finished, if there is some that already marked as finish delete them
+
+## Release system (release-it)
+
+* Use release-it for interactive version management and publishing.
 "
 `;

--- a/packages/builder/src/builder.spec.ts
+++ b/packages/builder/src/builder.spec.ts
@@ -100,6 +100,21 @@ describe("builder", () => {
     expect(response).toMatchSnapshot();
   });
 
+  test("working with release system only", async () => {
+    const response = await builder({ releaseSystem: "release-it" });
+
+    expect(response).toMatchSnapshot();
+  });
+
+  test("working with project type and release system", async () => {
+    const response = await builder({
+      projectType: "lib",
+      releaseSystem: "semantic-release",
+    });
+
+    expect(response).toMatchSnapshot();
+  });
+
   test("working with all options including framework", async () => {
     const response = await builder({
       language: "typescript",

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -5,6 +5,7 @@ import { languageSegment } from "./language/languageSegment";
 import { projectSegment } from "./project/projectSegment";
 import { frameworkSegment } from "./framework/frameworkSegment";
 import { lintSegment } from "./lint/lintSegment";
+import { releaseSegment } from "./release/releaseSegment";
 import { BuilderOptions } from "./BuilderOptions";
 
 export async function builder(options?: BuilderOptions): Promise<string> {
@@ -22,7 +23,14 @@ export async function builder(options?: BuilderOptions): Promise<string> {
   if (options === undefined) {
     return toMarkdown(tree);
   }
-  const { language, packageManager, projectType, framework, lintSystem } = options;
+  const {
+    language,
+    packageManager,
+    projectType,
+    framework,
+    lintSystem,
+    releaseSystem,
+  } = options;
   if (packageManager) {
     tree.children.push({
       type: "paragraph",
@@ -48,6 +56,10 @@ export async function builder(options?: BuilderOptions): Promise<string> {
 
   if (framework) {
     tree.children = tree.children.concat(await frameworkSegment(framework));
+  }
+
+  if (releaseSystem) {
+    tree.children = tree.children.concat(await releaseSegment(releaseSystem));
   }
 
   return toMarkdown(tree);

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -5,3 +5,5 @@ export { Languages } from "./language";
 export { ProjectTypes } from "./project";
 export { LintSystems, getAvailableLintSystems } from "./lint";
 export { lintSegment } from "./lint";
+export { ReleaseSystems, getAvailableReleaseSystems } from "./release";
+export { releaseSegment } from "./release";

--- a/packages/builder/src/release/__snapshots__/releaseSegment.spec.ts.snap
+++ b/packages/builder/src/release/__snapshots__/releaseSegment.spec.ts.snap
@@ -1,0 +1,40 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`releaseSegment > returns release system guidelines 1`] = `
+[
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "Release system",
+      },
+      {
+        "type": "text",
+        "value": " (release-it)",
+      },
+    ],
+    "depth": 2,
+    "type": "heading",
+  },
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "type": "text",
+                "value": "Use release-it for interactive version management and publishing.",
+              },
+            ],
+            "type": "paragraph",
+          },
+        ],
+        "type": "listItem",
+      },
+    ],
+    "ordered": false,
+    "type": "list",
+  },
+]
+`;

--- a/packages/builder/src/release/index.ts
+++ b/packages/builder/src/release/index.ts
@@ -1,0 +1,5 @@
+export { ReleaseSystems, getAvailableReleaseSystems } from "./options";
+export type { ReleaseSystemOption } from "./options";
+export { releaseSegment } from "./releaseSegment";
+export { releaseItRules } from "./release-it";
+export { semanticReleaseRules } from "./semantic-release";

--- a/packages/builder/src/release/options.ts
+++ b/packages/builder/src/release/options.ts
@@ -1,0 +1,12 @@
+export interface ReleaseSystemOption {
+  name: string;
+}
+
+export const ReleaseSystems: readonly ReleaseSystemOption[] = [
+  { name: "release-it" },
+  { name: "semantic-release" },
+] as const;
+
+export const getAvailableReleaseSystems = (): string[] => {
+  return ReleaseSystems.map((r) => r.name);
+};

--- a/packages/builder/src/release/release-it.ts
+++ b/packages/builder/src/release/release-it.ts
@@ -1,0 +1,5 @@
+export const releaseItRules = [
+  "Use release-it for interactive version management and publishing.",
+] as const;
+
+export type ReleaseItRule = (typeof releaseItRules)[number];

--- a/packages/builder/src/release/releaseSegment.spec.ts
+++ b/packages/builder/src/release/releaseSegment.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "vitest";
+import { releaseSegment } from "./releaseSegment";
+
+describe("releaseSegment", () => {
+  test("returns release system guidelines", async () => {
+    const segment = await releaseSegment("release-it");
+    expect(segment).toMatchSnapshot();
+  });
+});

--- a/packages/builder/src/release/releaseSegment.ts
+++ b/packages/builder/src/release/releaseSegment.ts
@@ -1,0 +1,39 @@
+import type { ListItem, RootContent } from "mdast";
+import { releaseItRules } from "./release-it";
+import { semanticReleaseRules } from "./semantic-release";
+
+const releaseRulesMap: Record<string, readonly string[]> = {
+  "release-it": releaseItRules,
+  "semantic-release": semanticReleaseRules,
+};
+
+export const releaseSegment = async (
+  releaseSystem: string
+): Promise<RootContent[]> => {
+  const releaseItems = releaseRulesMap[releaseSystem] ?? [];
+
+  const segment: RootContent[] = [
+    {
+      type: "heading",
+      depth: 2,
+      children: [
+        { type: "text", value: "Release system" },
+        { type: "text", value: ` (${releaseSystem})` },
+      ],
+    },
+    {
+      type: "list",
+      ordered: false,
+      children: releaseItems.map(
+        (item): ListItem => ({
+          type: "listItem",
+          children: [
+            { type: "paragraph", children: [{ type: "text", value: item }] },
+          ],
+        })
+      ),
+    },
+  ];
+
+  return segment;
+};

--- a/packages/builder/src/release/semantic-release.ts
+++ b/packages/builder/src/release/semantic-release.ts
@@ -1,0 +1,5 @@
+export const semanticReleaseRules = [
+  "Use semantic-release for automated versioning and changelog generation.",
+] as const;
+
+export type SemanticReleaseRule = (typeof semanticReleaseRules)[number];


### PR DESCRIPTION
## Summary
- let CLI choose release manager when building libs
- support release system segment in builder
- add tests for release rules
- mark release manager TODO as done

## Testing
- `pnpm --filter @vibe-builder/builder test`
- `pnpm --filter @vibe-builder/builder build`
- `pnpm --filter @vibe-builder/cli build`


------
https://chatgpt.com/codex/tasks/task_e_68500ebf51ac8332bc5873682a0c2254