### PR TITLE
Add turborepo setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 tsconfig.tsbuildinfo
 dist/
+.turbo

--- a/README.md
+++ b/README.md
@@ -10,3 +10,11 @@ To use the prompts you have two options:
 
 1. **Copy and paste** the prompts from the files in this repository into your coding agent.
 2. **Generate the Agents.md file** by cloning this repository and running the `sh merge.sh` script. This will create a single `Agents.md` file that contains all the prompts from the individual files.
+
+## Development
+
+This repository uses [Turborepo](https://turbo.build) for managing tasks across packages.
+
+- `pnpm build` - run build in all packages
+- `pnpm lint` - run type checking
+- `pnpm test` - run unit tests

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,6 @@
 - [ ] When building a lib or any of its subsets, let the user choose also the publishing manager, for example: release-it and semantic-release
 
 - [ ] Make the publish step for the builder to run in dry run, wait for a dev ik and only then publish the package.
-
-- [ ] Implement turbo repo to the project.
+- [x] Implement turbo repo to the project.
 
 - [ ] Remove .spec file from type checking and building

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -10,6 +10,7 @@
     "build": "tsc",
     "prebuild": "rimraf dist",
     "start:cli": "node dist/main.js",
+    "lint": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest watch"
   },

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -47,7 +47,7 @@
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */

--- a/package.json
+++ b/package.json
@@ -6,5 +6,13 @@
   "workspaces": [
     "packages/builder",
     "apps/cli"
-  ]
+  ],
+  "scripts": {
+    "build": "turbo build",
+    "lint": "turbo lint",
+    "test": "turbo test"
+  },
+  "devDependencies": {
+    "turbo": "^2.5.4"
+  }
 }

--- a/packages/builder/tsconfig.json
+++ b/packages/builder/tsconfig.json
@@ -47,7 +47,7 @@
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      turbo:
+        specifier: ^2.5.4
+        version: 2.5.4
 
   apps/cli:
     dependencies:
@@ -1330,6 +1334,40 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  turbo-darwin-64@2.5.4:
+    resolution: {integrity: sha512-ah6YnH2dErojhFooxEzmvsoZQTMImaruZhFPfMKPBq8sb+hALRdvBNLqfc8NWlZq576FkfRZ/MSi4SHvVFT9PQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  turbo-darwin-arm64@2.5.4:
+    resolution: {integrity: sha512-2+Nx6LAyuXw2MdXb7pxqle3MYignLvS7OwtsP9SgtSBaMlnNlxl9BovzqdYAgkUW3AsYiQMJ/wBRb7d+xemM5A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  turbo-linux-64@2.5.4:
+    resolution: {integrity: sha512-5May2kjWbc8w4XxswGAl74GZ5eM4Gr6IiroqdLhXeXyfvWEdm2mFYCSWOzz0/z5cAgqyGidF1jt1qzUR8hTmOA==}
+    cpu: [x64]
+    os: [linux]
+
+  turbo-linux-arm64@2.5.4:
+    resolution: {integrity: sha512-/2yqFaS3TbfxV3P5yG2JUI79P7OUQKOUvAnx4MV9Bdz6jqHsHwc9WZPpO4QseQm+NvmgY6ICORnoVPODxGUiJg==}
+    cpu: [arm64]
+    os: [linux]
+
+  turbo-windows-64@2.5.4:
+    resolution: {integrity: sha512-EQUO4SmaCDhO6zYohxIjJpOKRN3wlfU7jMAj3CgcyTPvQR/UFLEKAYHqJOnJtymbQmiiM/ihX6c6W6Uq0yC7mA==}
+    cpu: [x64]
+    os: [win32]
+
+  turbo-windows-arm64@2.5.4:
+    resolution: {integrity: sha512-oQ8RrK1VS8lrxkLriotFq+PiF7iiGgkZtfLKF4DDKsmdbPo0O9R2mQxm7jHLuXraRCuIQDWMIw6dpcr7Iykf4A==}
+    cpu: [arm64]
+    os: [win32]
+
+  turbo@2.5.4:
+    resolution: {integrity: sha512-kc8ZibdRcuWUG1pbYSBFWqmIjynlD8Lp7IB6U3vIzvOv9VG+6Sp8bzyeBWE3Oi8XV5KsQrznyRTBPvrf99E4mA==}
+    hasBin: true
 
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
@@ -2684,6 +2722,33 @@ snapshots:
   totalist@3.0.1: {}
 
   tslib@2.8.1: {}
+
+  turbo-darwin-64@2.5.4:
+    optional: true
+
+  turbo-darwin-arm64@2.5.4:
+    optional: true
+
+  turbo-linux-64@2.5.4:
+    optional: true
+
+  turbo-linux-arm64@2.5.4:
+    optional: true
+
+  turbo-windows-64@2.5.4:
+    optional: true
+
+  turbo-windows-arm64@2.5.4:
+    optional: true
+
+  turbo@2.5.4:
+    optionalDependencies:
+      turbo-darwin-64: 2.5.4
+      turbo-darwin-arm64: 2.5.4
+      turbo-linux-64: 2.5.4
+      turbo-linux-arm64: 2.5.4
+      turbo-windows-64: 2.5.4
+      turbo-windows-arm64: 2.5.4
 
   type-fest@0.21.3: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "lint": {
+      "outputs": []
+    },
+    "test": {
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- integrate Turborepo and add basic pipeline
- document usage of turbo in README
- ignore `.turbo` cache
- add lint script to CLI package
- configure TypeScript to use node module resolution
- update lockfile
- mark turbo task as done in TODO

## Testing
- `pnpm lint` *(fails: command exited with error)*
- `pnpm test` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_6850177ab25483328a1bbda09351722d