### PR TITLE
Add monorepo system support to builder

### DIFF
--- a/packages/builder/TODO.md
+++ b/packages/builder/TODO.md
@@ -2,4 +2,4 @@
 
 - [ ] Add test that validate that only libs projects can have publish system, validate that the types are type-safe as well.
 
-- [ ] Add monorepo management system, for now the options are TurboRepo, Nx and Lerna, this segment is like the package manager, its do not have rules just a line that mentions the system used.
+- [x] Add monorepo management system, for now the options are TurboRepo, Nx and Lerna, this segment is like the package manager, its do not have rules just a line that mentions the system used.

--- a/packages/builder/src/BuilderOptions.spec.ts
+++ b/packages/builder/src/BuilderOptions.spec.ts
@@ -44,4 +44,12 @@ describe("BuilderOptions", () => {
       releaseSystem: "semantic-release",
     });
   });
+
+  it("should accept monorepoSystem without restrictions", () => {
+    assertType<BuilderOptions>({ monorepoSystem: "turbo" });
+    assertType<BuilderOptions>({
+      projectType: "lib",
+      monorepoSystem: "nx",
+    });
+  });
 });

--- a/packages/builder/src/BuilderOptions.ts
+++ b/packages/builder/src/BuilderOptions.ts
@@ -2,6 +2,7 @@ type BaseBuilderOptions = {
   projectType?: string;
   framework?: string;
   releaseSystem?: string;
+  monorepoSystem?: string;
 };
 type BuilderOptionsWithLanguage = {
   language: string;

--- a/packages/builder/src/__snapshots__/builder.spec.ts.snap
+++ b/packages/builder/src/__snapshots__/builder.spec.ts.snap
@@ -328,6 +328,35 @@ exports[`builder > working with language, project type and framework 1`] = `
 "
 `;
 
+exports[`builder > working with monorepo system only 1`] = `
+"# AI agent instructions
+
+## General Guidelines
+
+* Don't work on any of the tasks in the TODO.md file unless you are asked to.
+
+* Always try to early return from functions.
+
+* Use \\\`const\\\` for variables that are not reassigned.
+
+* Make sure to focus on why and not how in documentation.
+
+* Write predictable functions and make a spec file for them according to the testing library in use.
+
+* Don't use \\\`any\\\` in TypeScript, use \\\`unknown\\\` instead.
+
+* Don't cast types without validation.
+
+* Whenever finish a task from the TODO.md file mark it as finished, if there is some that already marked as finish delete them
+
+* Work in a domain driven design (DDD) way, i.e. every function its is own module, and its its folder there is the code with JSDocs, spec file and types in there files.
+
+* Put unit tests in the same folder as the code they test, and name them with \\\`.spec.ts\\\` suffix.
+
+Monorepo system: turbo
+"
+`;
+
 exports[`builder > working with no arguments returns general segment only 1`] = `
 "# AI agent instructions
 
@@ -426,6 +455,53 @@ exports[`builder > working with project type and framework - frontend with react
 ## Framework (react)
 
 * Use key in React lists to help React identify which items have changed, are added, or removed.
+"
+`;
+
+exports[`builder > working with project type and monorepo system 1`] = `
+"# AI agent instructions
+
+## General Guidelines
+
+* Don't work on any of the tasks in the TODO.md file unless you are asked to.
+
+* Always try to early return from functions.
+
+* Use \\\`const\\\` for variables that are not reassigned.
+
+* Make sure to focus on why and not how in documentation.
+
+* Write predictable functions and make a spec file for them according to the testing library in use.
+
+* Don't use \\\`any\\\` in TypeScript, use \\\`unknown\\\` instead.
+
+* Don't cast types without validation.
+
+* Whenever finish a task from the TODO.md file mark it as finished, if there is some that already marked as finish delete them
+
+* Work in a domain driven design (DDD) way, i.e. every function its is own module, and its its folder there is the code with JSDocs, spec file and types in there files.
+
+* Put unit tests in the same folder as the code they test, and name them with \\\`.spec.ts\\\` suffix.
+
+Monorepo system: nx
+
+## Project type (lib)
+
+* Work with version control for publish the package if its publishable
+
+* Create a clear and comprehensive README.md with installation instructions, usage examples, and API documentation
+
+* Use semantic versioning (semver) for package versions
+
+* Include proper TypeScript declaration files (.d.ts) for better developer experience
+
+* Set up automated testing with good test coverage before publishing
+
+* Configure proper entry points in package.json (main, module, types fields)
+
+* Consider tree-shaking compatibility by using ES modules
+
+* Add proper keywords and description in package.json for discoverability
 "
 `;
 

--- a/packages/builder/src/builder.spec.ts
+++ b/packages/builder/src/builder.spec.ts
@@ -115,6 +115,21 @@ describe("builder", () => {
     expect(response).toMatchSnapshot();
   });
 
+  test("working with monorepo system only", async () => {
+    const response = await builder({ monorepoSystem: "turbo" });
+
+    expect(response).toMatchSnapshot();
+  });
+
+  test("working with project type and monorepo system", async () => {
+    const response = await builder({
+      projectType: "lib",
+      monorepoSystem: "nx",
+    });
+
+    expect(response).toMatchSnapshot();
+  });
+
   test("working with all options including framework", async () => {
     const response = await builder({
       language: "typescript",

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -6,6 +6,7 @@ import { projectSegment } from "./project/projectSegment";
 import { frameworkSegment } from "./framework/frameworkSegment";
 import { lintSegment } from "./lint/lintSegment";
 import { releaseSegment } from "./release/releaseSegment";
+import { monorepoSegment } from "./monorepo/monorepoSegment";
 import { BuilderOptions } from "./BuilderOptions";
 
 export async function builder(options?: BuilderOptions): Promise<string> {
@@ -30,6 +31,7 @@ export async function builder(options?: BuilderOptions): Promise<string> {
     framework,
     lintSystem,
     releaseSystem,
+    monorepoSystem,
   } = options;
   if (packageManager) {
     tree.children.push({
@@ -41,6 +43,12 @@ export async function builder(options?: BuilderOptions): Promise<string> {
         },
       ],
     });
+  }
+
+  if (monorepoSystem) {
+    tree.children = tree.children.concat(
+      await monorepoSegment(monorepoSystem)
+    );
   }
 
   if (language) {

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -7,3 +7,8 @@ export { LintSystems, getAvailableLintSystems } from "./lint";
 export { lintSegment } from "./lint";
 export { ReleaseSystems, getAvailableReleaseSystems } from "./release";
 export { releaseSegment } from "./release";
+export {
+  MonorepoSystems,
+  getAvailableMonorepoSystems,
+  monorepoSegment,
+} from "./monorepo";

--- a/packages/builder/src/monorepo/__snapshots__/monorepoSegment.spec.ts.snap
+++ b/packages/builder/src/monorepo/__snapshots__/monorepoSegment.spec.ts.snap
@@ -1,0 +1,15 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`monorepoSegment > returns monorepo system line 1`] = `
+[
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "Monorepo system: turbo",
+      },
+    ],
+    "type": "paragraph",
+  },
+]
+`;

--- a/packages/builder/src/monorepo/index.ts
+++ b/packages/builder/src/monorepo/index.ts
@@ -1,0 +1,3 @@
+export { MonorepoSystems, getAvailableMonorepoSystems } from "./options";
+export { monorepoSegment } from "./monorepoSegment";
+export type { MonorepoSystemOption } from "./options";

--- a/packages/builder/src/monorepo/monorepoSegment.spec.ts
+++ b/packages/builder/src/monorepo/monorepoSegment.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "vitest";
+import { monorepoSegment } from "./monorepoSegment";
+
+describe("monorepoSegment", () => {
+  test("returns monorepo system line", async () => {
+    const segment = await monorepoSegment("turbo");
+    expect(segment).toMatchSnapshot();
+  });
+});

--- a/packages/builder/src/monorepo/monorepoSegment.ts
+++ b/packages/builder/src/monorepo/monorepoSegment.ts
@@ -1,0 +1,19 @@
+import type { RootContent } from "mdast";
+
+export const monorepoSegment = async (
+  system: string
+): Promise<RootContent[]> => {
+  const segment: RootContent[] = [
+    {
+      type: "paragraph",
+      children: [
+        {
+          type: "text",
+          value: `Monorepo system: ${system}`,
+        },
+      ],
+    },
+  ];
+
+  return segment;
+};

--- a/packages/builder/src/monorepo/options.ts
+++ b/packages/builder/src/monorepo/options.ts
@@ -1,0 +1,13 @@
+export interface MonorepoSystemOption {
+  name: string;
+}
+
+export const MonorepoSystems: readonly MonorepoSystemOption[] = [
+  { name: "turbo" },
+  { name: "nx" },
+  { name: "lerna" },
+] as const;
+
+export const getAvailableMonorepoSystems = (): string[] => {
+  return MonorepoSystems.map((system) => system.name);
+};


### PR DESCRIPTION
## Summary
- support monorepo systems in builder
- export monorepo utilities
- add monorepo segment and tests
- include new tests and snapshots
- mark TODO item as complete

## Testing
- `npx vitest run`
- `pnpm --filter @vibe-builder/builder lint`

------
https://chatgpt.com/codex/tasks/task_e_6850192cdf9c833281bd3a74f73e4266