### PR TITLE
Remove spec files from build

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,4 +9,4 @@
 - [ ] Make the publish step for the builder to run in dry run, wait for a dev ik and only then publish the package.
 - [x] Implement turbo repo to the project.
 
-- [ ] Remove .spec file from type checking and building
+- [x] Remove .spec file from type checking and building

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -79,6 +79,7 @@
     "tests",
     "coverage",
     "docs",
-    "src/__tests__"
+    "src/__tests__",
+    "**/*.spec.ts"
   ]
 }

--- a/packages/builder/tsconfig.json
+++ b/packages/builder/tsconfig.json
@@ -72,5 +72,13 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "exclude": ["node_modules", "dist", "test", "tests", "coverage", "docs"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "test",
+    "tests",
+    "coverage",
+    "docs",
+    "**/*.spec.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- exclude `.spec.ts` files from TypeScript builds
- mark TODO as finished

## Testing
- `pnpm run lint` in `apps/cli`
- `pnpm run lint` in `packages/builder`
- `pnpm run test` in `packages/builder`
- `pnpm run test` in `apps/cli`


------
https://chatgpt.com/codex/tasks/task_e_6850198e8af88332bfeeea7175e51ed4