### PR TITLE
Implement release-it in CI

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -54,18 +54,6 @@ jobs:
         run: pnpm install
       - name: Build
         run: pnpm run build
-      - name: Check version change
-        id: version
-        run: |
-          prev=$(git show HEAD^:packages/builder/package.json | jq -r '.version')
-          curr=$(jq -r '.version' package.json)
-          if [ "$curr" != "$prev" ]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-    outputs:
-      changed: ${{ steps.version.outputs.changed }}
 
   test:
     runs-on: ubuntu-latest
@@ -92,7 +80,7 @@ jobs:
 
   publish:
     needs: [lint, build, test]
-    if: github.event_name == 'push' && needs.build.outputs.changed == 'true'
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -113,6 +101,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Publish
-        run: pnpm --filter ./packages/builder publish --no-git-checks
+        run: pnpm --filter ./packages/builder run release -- --ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,4 @@
 3. [ ] When building a lib or any of its subsets, let the user choose also the publishing manager, for example: release-it and semantic-release
 
 4. [ ] Make the publish step for the builder to run in dry run, wait for a dev ik and only then publish the package.
-5. [x] Implement turbo repo to the project.
-
-6. [ ] Covert the CI/CD to work with the release system release-it
+5. [x] Covert the CI/CD to work with the release system release-it


### PR DESCRIPTION
## Summary
- update CI to publish with release-it
- mark CI/CD todo as completed

## Testing
- `pnpm lint` *(fails: tsc errors in cli package)*
- `pnpm build` *(fails: network issues fetching pnpm)*
- `pnpm test` *(fails: network issues fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68501f2bc52083329bc3dfb8b1dd2243