### PR TITLE
Add release system prompt test

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,4 @@
 
 2. [ ] Make the ui-lib be a superset of the lib project so when ever the ui-lib is been selected it will also include the lib rules.
 
-3. [ ] When building a lib or any of its subsets, let the user choose also the publishing manager, for example: release-it and semantic-release
-
 4. [ ] Make the publish step for the builder to run in dry run, wait for a dev ik and only then publish the package.
-5. [x] Implement turbo repo to the project.

--- a/apps/cli/src/__tests__/getReleaseSystem.spec.ts
+++ b/apps/cli/src/__tests__/getReleaseSystem.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { select } from "@inquirer/prompts";
+
+const systems = ["release-it", "semantic-release"];
+
+vi.mock("@vibe-builder/builder", () => ({
+  getAvailableReleaseSystems: () => systems,
+}));
+vi.mock("@inquirer/prompts", () => ({
+  select: vi.fn(),
+}));
+
+describe("getReleaseSystem", () => {
+  it("prompts user with release system options", async () => {
+    const selectMock = vi.mocked(select);
+    selectMock.mockResolvedValueOnce("release-it");
+    const { getReleaseSystem } = await import("../getReleaseSystem");
+
+    const result = await getReleaseSystem();
+
+    expect(result).toBe("release-it");
+    expect(selectMock).toHaveBeenCalledWith({
+      message: "Which release system would you like to use?",
+      default: "release-it",
+      choices: systems.map((system) => ({ name: system, value: system })),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add missing test for selecting release system
- remove the done release system todo

## Testing
- `pnpm build`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68501da5b76c833292aa0789cbf2cf9e