### PR TITLE
Fix builder publish workflow

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -82,6 +82,9 @@ jobs:
     needs: [lint, build, test]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/builder
     steps:
       - uses: actions/checkout@v4
         with:
@@ -97,6 +100,8 @@ jobs:
           version: 10.12.1
       - name: Install dependencies
         run: pnpm install
+      - name: Build
+        run: pnpm run build
       - name: Publish
         run: pnpm --filter @vibe-builder/builder run release -- --ci
         env:

--- a/packages/builder/TODO.md
+++ b/packages/builder/TODO.md
@@ -2,4 +2,4 @@
 
 1. [ ] Add test that validate that only libs projects can have release system, validate that the types are type-safe as well.
 
-2. [ ] Fix the CI/CD to publish this package to npm.
+2. [x] Fix the CI/CD to publish this package to npm.


### PR DESCRIPTION
## Summary
- add working directory and build step to builder publish job
- mark TODO as done

## Testing
- `pnpm lint` *(fails: ENETUNREACH for registry.npmjs.org)*
- `pnpm test` *(fails: ENETUNREACH for registry.npmjs.org)*
- `pnpm build` *(fails: ENETUNREACH for registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685024a368608332b9ab8fa199009510