### PR TITLE
Implement monorepo selection

### DIFF
--- a/apps/cli/TODO.md
+++ b/apps/cli/TODO.md
@@ -4,9 +4,8 @@
 
 2. [ ] Add to the CI running lint, test and build steps for the cli as like the builder
 
-3. [ ] Add option to select monorepo management system.
+3. [x] Add option to select monorepo management system.
 
 4. [ ] Add publish step to the CI, the same as the builder.
 
-5. [x] Add option to skip release system.
-
+5. [ ] Add option to add ui framework when choosing ui-lib and its depends on the project framework you choose, for example react will have tailwind and MUI.

--- a/apps/cli/src/__tests__/getMonorepoSystem.spec.ts
+++ b/apps/cli/src/__tests__/getMonorepoSystem.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { select } from "@inquirer/prompts";
+
+const systems = ["turbo", "nx", "lerna"];
+
+vi.mock("@vibe-builder/builder", () => ({
+  getAvailableMonorepoSystems: () => systems,
+}));
+vi.mock("@inquirer/prompts", () => ({
+  select: vi.fn(),
+}));
+
+describe("getMonorepoSystem", () => {
+  it("prompts user with monorepo system options", async () => {
+    const selectMock = vi.mocked(select);
+    selectMock.mockResolvedValueOnce("nx");
+    const { getMonorepoSystem } = await import("../getMonorepoSystem");
+
+    const result = await getMonorepoSystem();
+
+    expect(result).toBe("nx");
+    expect(selectMock).toHaveBeenCalledWith({
+      message: "Which monorepo system would you like to use?",
+      default: null,
+      choices: [
+        { name: "None", value: null },
+        ...systems.map((system) => ({ name: system, value: system })),
+        { name: "Skip", value: null },
+      ],
+    });
+  });
+
+  it("returns null when skip is chosen", async () => {
+    const selectMock = vi.mocked(select);
+    selectMock.mockResolvedValueOnce(null);
+    const { getMonorepoSystem } = await import("../getMonorepoSystem");
+
+    const result = await getMonorepoSystem();
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/cli/src/getMonorepoSystem.ts
+++ b/apps/cli/src/getMonorepoSystem.ts
@@ -1,0 +1,22 @@
+import { select } from "@inquirer/prompts";
+import { getAvailableMonorepoSystems } from "@vibe-builder/builder";
+
+export const getMonorepoSystem = async () => {
+  const availableSystems = getAvailableMonorepoSystems();
+
+  if (availableSystems.length === 0) {
+    return null;
+  }
+
+  const choices = [
+    { name: "None", value: null },
+    ...availableSystems.map((system) => ({ name: system, value: system })),
+    { name: "Skip", value: null },
+  ];
+
+  return select({
+    message: "Which monorepo system would you like to use?",
+    default: null,
+    choices,
+  });
+};

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -8,6 +8,7 @@ import { getLintSystem } from "./getLintSystem";
 import { outputPath } from "./outputPath";
 import { getPackageManager } from "./getPackageManager/getPackageManager";
 import { getReleaseSystem } from "./getReleaseSystem";
+import { getMonorepoSystem } from "./getMonorepoSystem";
 
 export const main = async () => {
   let builderOptions: BuilderOptions = {};
@@ -31,6 +32,11 @@ export const main = async () => {
     if (releaseSystem) {
       builderOptions.releaseSystem = releaseSystem;
     }
+  }
+
+  const monorepoSystem = await getMonorepoSystem();
+  if (monorepoSystem) {
+    builderOptions.monorepoSystem = monorepoSystem;
   }
 
   // Get framework based on selected project type


### PR DESCRIPTION
## Summary
- add option to choose monorepo system in the CLI
- call new selection function from `main`
- test monorepo selection logic
- update TODO files

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/latest)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/latest)*
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/latest)*

------
https://chatgpt.com/codex/tasks/task_e_685024229eb483329aaa40a680cdac91