### PR TITLE
Add publish workflow for CLI

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,104 @@
+name: CLI CI/CD
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/cli
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10.12.1
+      - name: Install dependencies
+        run: pnpm install
+      - name: Lint
+        run: pnpm run lint
+
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/cli
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10.12.1
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build
+        run: pnpm run build
+
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/cli
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10.12.1
+      - name: Install dependencies
+        run: pnpm install
+      - name: Test
+        run: pnpm run test
+
+  publish:
+    needs: [lint, build, test]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10.12.1
+      - name: Install dependencies
+        run: pnpm install
+      - name: Publish
+        run: pnpm --filter @vibe-builder/cli run release -- --ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/cli/TODO.md
+++ b/apps/cli/TODO.md
@@ -6,7 +6,7 @@
 
 3. [ ] Add option to select monorepo management system.
 
-4. [ ] Add publish step to the CI, the same as the builder.
+4. [x] Add publish step to the CI, the same as the builder.
 
 5. [x] Add option to skip release system.
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -12,7 +12,8 @@
     "start:cli": "node dist/main.js",
     "lint": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest watch"
+    "test:watch": "vitest watch",
+    "release": "release-it"
   },
   "bin": {
     "vibe-builder": "dist/main.js"
@@ -25,10 +26,27 @@
     "@types/node": "^24.0.1",
     "rimraf": "^6.0.1",
     "typescript": "~5.1.6",
-    "vitest": "^3.2.3"
+    "vitest": "^3.2.3",
+    "release-it": "^19.0.3"
   },
   "dependencies": {
     "@inquirer/prompts": "^7.5.3",
     "@vibe-builder/builder": "workspace:^"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "release-it": {
+    "git": {
+      "tagName": "v${version}",
+      "commitMessage": "chore: release v${version}"
+    },
+    "npm": {
+      "publish": true,
+      "access": "public"
+    },
+    "github": {
+      "release": true
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@types/node':
         specifier: ^24.0.1
         version: 24.0.3
+      release-it:
+        specifier: ^19.0.3
+        version: 19.0.3(@types/node@24.0.3)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1


### PR DESCRIPTION
## Summary
- add CI workflow to lint, build, test and publish the CLI package
- configure release-it for the CLI
- mark TODO as done

## Testing
- `pnpm install`
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm test` *(fails: ENETUNREACH)*
- `pnpm build` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68502527c2248332be692dbb0ba68ee5