### PR TITLE
Implement createdAt timestamp option

### DIFF
--- a/packages/builder/TODO.md
+++ b/packages/builder/TODO.md
@@ -4,5 +4,5 @@
 
 2. [x] Fix the CI/CD to publish this package to npm.
 
-3. [ ] Add the option to add "create at" timestamp to the generated files, it will be in the end of the file and will be optional, add snapshot tests for this feature.
+3. [x] Add the option to add "create at" timestamp to the generated files, it will be in the end of the file and will be optional, add snapshot tests for this feature.
 

--- a/packages/builder/src/BuilderOptions.spec.ts
+++ b/packages/builder/src/BuilderOptions.spec.ts
@@ -52,4 +52,8 @@ describe("BuilderOptions", () => {
       monorepoSystem: "nx",
     });
   });
+
+  it("should accept createdAt option", () => {
+    assertType<BuilderOptions>({ createdAt: true });
+  });
 });

--- a/packages/builder/src/BuilderOptions.ts
+++ b/packages/builder/src/BuilderOptions.ts
@@ -3,6 +3,7 @@ type BaseBuilderOptions = {
   framework?: string;
   releaseSystem?: string;
   monorepoSystem?: string;
+  createdAt?: boolean;
 };
 type BuilderOptionsWithLanguage = {
   language: string;

--- a/packages/builder/src/__snapshots__/builder.spec.ts.snap
+++ b/packages/builder/src/__snapshots__/builder.spec.ts.snap
@@ -59,6 +59,35 @@ Package Manager: npm
 "
 `;
 
+exports[`builder > working with createdAt option 1`] = `
+"# AI agent instructions
+
+## General Guidelines
+
+* Don't work on any of the tasks in the TODO.md file unless you are asked to.
+
+* Always try to early return from functions.
+
+* Use \\\`const\\\` for variables that are not reassigned.
+
+* Make sure to focus on why and not how in documentation.
+
+* Write predictable functions and make a spec file for them according to the testing library in use.
+
+* Don't use \\\`any\\\` in TypeScript, use \\\`unknown\\\` instead.
+
+* Don't cast types without validation.
+
+* Whenever finish a task from the TODO.md file mark it as finished, if there is some that already marked as finish delete them
+
+* Work in a domain driven design (DDD) way, i.e. every function its is own module, and its its folder there is the code with JSDocs, spec file and types in there files.
+
+* Put unit tests in the same folder as the code they test, and name them with \\\`.spec.ts\\\` suffix.
+
+Created at: 2020-01-01T00:00:00.000Z
+"
+`;
+
 exports[`builder > working with framework only - nestjs 1`] = `
 "# AI agent instructions
 

--- a/packages/builder/src/builder.spec.ts
+++ b/packages/builder/src/builder.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { builder } from "./builder";
 describe("builder", () => {
   test("working with no arguments returns general segment only", async () => {
@@ -140,5 +140,14 @@ describe("builder", () => {
     });
 
     expect(response).toMatchSnapshot();
+  });
+
+  test("working with createdAt option", async () => {
+    const date = new Date("2020-01-01T00:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(date);
+    const response = await builder({ createdAt: true });
+    expect(response).toMatchSnapshot();
+    vi.useRealTimers();
   });
 });

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -8,6 +8,7 @@ import { lintSegment } from "./lint/lintSegment";
 import { releaseSegment } from "./release/releaseSegment";
 import { monorepoSegment } from "./monorepo/monorepoSegment";
 import { BuilderOptions } from "./BuilderOptions";
+import { createdAtSegment } from "./createdAt/createdAtSegment";
 
 export async function builder(options?: BuilderOptions): Promise<string> {
   const tree: Root = {
@@ -32,6 +33,7 @@ export async function builder(options?: BuilderOptions): Promise<string> {
     lintSystem,
     releaseSystem,
     monorepoSystem,
+    createdAt,
   } = options;
   if (packageManager) {
     tree.children.push({
@@ -68,6 +70,10 @@ export async function builder(options?: BuilderOptions): Promise<string> {
 
   if (releaseSystem) {
     tree.children = tree.children.concat(await releaseSegment(releaseSystem));
+  }
+
+  if (createdAt) {
+    tree.children = tree.children.concat(await createdAtSegment());
   }
 
   return toMarkdown(tree);

--- a/packages/builder/src/createdAt/__snapshots__/createdAtSegment.spec.ts.snap
+++ b/packages/builder/src/createdAt/__snapshots__/createdAtSegment.spec.ts.snap
@@ -1,0 +1,15 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`createdAtSegment > returns timestamp segment 1`] = `
+[
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "Created at: 2020-01-01T00:00:00.000Z",
+      },
+    ],
+    "type": "paragraph",
+  },
+]
+`;

--- a/packages/builder/src/createdAt/createdAtSegment.spec.ts
+++ b/packages/builder/src/createdAt/createdAtSegment.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "vitest";
+import { createdAtSegment } from "./createdAtSegment";
+
+describe("createdAtSegment", () => {
+  test("returns timestamp segment", async () => {
+    const date = new Date("2020-01-01T00:00:00.000Z");
+    const segment = await createdAtSegment(date);
+    expect(segment).toMatchSnapshot();
+  });
+});

--- a/packages/builder/src/createdAt/createdAtSegment.ts
+++ b/packages/builder/src/createdAt/createdAtSegment.ts
@@ -1,0 +1,20 @@
+import type { RootContent } from "mdast";
+
+/**
+ * Generate a "Created at" timestamp segment.
+ *
+ * @returns markdown AST nodes representing the timestamp
+ */
+export const createdAtSegment = async (date: Date = new Date()): Promise<RootContent[]> => {
+  const now = date.toISOString();
+  const segment: RootContent[] = [
+    {
+      type: "paragraph",
+      children: [
+        { type: "text", value: `Created at: ${now}` },
+      ],
+    },
+  ];
+
+  return segment;
+};

--- a/packages/builder/src/createdAt/index.ts
+++ b/packages/builder/src/createdAt/index.ts
@@ -1,0 +1,1 @@
+export { createdAtSegment } from "./createdAtSegment";

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -12,3 +12,4 @@ export {
   getAvailableMonorepoSystems,
   monorepoSegment,
 } from "./monorepo";
+export { createdAtSegment } from "./createdAt";


### PR DESCRIPTION
## Summary
- add optional createdAt timestamp segment
- update BuilderOptions type and tests
- support timestamp in builder output
- snapshot tests for deterministic date
- mark TODO item done

## Testing
- `pnpm --filter ./packages/builder test`
- `pnpm --filter ./packages/builder test:update`

------
https://chatgpt.com/codex/tasks/task_e_68502719c33483328e1aef2e6d457c94