### PR TITLE
Implement CI/CD segment

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,4 +10,4 @@
 
 5. [ ] Add option to add ui framework when choosing ui-lib and its depends on the project framework you choose, for example react will have tailwind and MUI.
 
-6. [ ] Add segment for CI/CD framework, like github actions, gitlab ci, circleci, etc. and then add the option to select the CI/CD system in the builder, it will be like the monorepo management system only, without rules.
+6. [x] Add segment for CI/CD framework, like github actions, gitlab ci, circleci, etc. and then add the option to select the CI/CD system in the builder, it will be like the monorepo management system only, without rules.

--- a/packages/builder/src/BuilderOptions.spec.ts
+++ b/packages/builder/src/BuilderOptions.spec.ts
@@ -52,4 +52,12 @@ describe("BuilderOptions", () => {
       monorepoSystem: "nx",
     });
   });
+
+  it("should accept cicdSystem without restrictions", () => {
+    assertType<BuilderOptions>({ cicdSystem: "github-actions" });
+    assertType<BuilderOptions>({
+      projectType: "lib",
+      cicdSystem: "gitlab-ci",
+    });
+  });
 });

--- a/packages/builder/src/BuilderOptions.ts
+++ b/packages/builder/src/BuilderOptions.ts
@@ -3,6 +3,7 @@ type BaseBuilderOptions = {
   framework?: string;
   releaseSystem?: string;
   monorepoSystem?: string;
+  cicdSystem?: string;
 };
 type BuilderOptionsWithLanguage = {
   language: string;

--- a/packages/builder/src/__snapshots__/builder.spec.ts.snap
+++ b/packages/builder/src/__snapshots__/builder.spec.ts.snap
@@ -59,6 +59,35 @@ Package Manager: npm
 "
 `;
 
+exports[`builder > working with cicd system only 1`] = `
+"# AI agent instructions
+
+## General Guidelines
+
+* Don't work on any of the tasks in the TODO.md file unless you are asked to.
+
+* Always try to early return from functions.
+
+* Use \\\`const\\\` for variables that are not reassigned.
+
+* Make sure to focus on why and not how in documentation.
+
+* Write predictable functions and make a spec file for them according to the testing library in use.
+
+* Don't use \\\`any\\\` in TypeScript, use \\\`unknown\\\` instead.
+
+* Don't cast types without validation.
+
+* Whenever finish a task from the TODO.md file mark it as finished, if there is some that already marked as finish delete them
+
+* Work in a domain driven design (DDD) way, i.e. every function its is own module, and its its folder there is the code with JSDocs, spec file and types in there files.
+
+* Put unit tests in the same folder as the code they test, and name them with \\\`.spec.ts\\\` suffix.
+
+CI/CD system: github-actions
+"
+`;
+
 exports[`builder > working with framework only - nestjs 1`] = `
 "# AI agent instructions
 
@@ -381,6 +410,53 @@ exports[`builder > working with no arguments returns general segment only 1`] = 
 * Work in a domain driven design (DDD) way, i.e. every function its is own module, and its its folder there is the code with JSDocs, spec file and types in there files.
 
 * Put unit tests in the same folder as the code they test, and name them with \\\`.spec.ts\\\` suffix.
+"
+`;
+
+exports[`builder > working with project type and cicd system 1`] = `
+"# AI agent instructions
+
+## General Guidelines
+
+* Don't work on any of the tasks in the TODO.md file unless you are asked to.
+
+* Always try to early return from functions.
+
+* Use \\\`const\\\` for variables that are not reassigned.
+
+* Make sure to focus on why and not how in documentation.
+
+* Write predictable functions and make a spec file for them according to the testing library in use.
+
+* Don't use \\\`any\\\` in TypeScript, use \\\`unknown\\\` instead.
+
+* Don't cast types without validation.
+
+* Whenever finish a task from the TODO.md file mark it as finished, if there is some that already marked as finish delete them
+
+* Work in a domain driven design (DDD) way, i.e. every function its is own module, and its its folder there is the code with JSDocs, spec file and types in there files.
+
+* Put unit tests in the same folder as the code they test, and name them with \\\`.spec.ts\\\` suffix.
+
+CI/CD system: gitlab-ci
+
+## Project type (lib)
+
+* Work with version control for publish the package if its publishable
+
+* Create a clear and comprehensive README.md with installation instructions, usage examples, and API documentation
+
+* Use semantic versioning (semver) for package versions
+
+* Include proper TypeScript declaration files (.d.ts) for better developer experience
+
+* Set up automated testing with good test coverage before publishing
+
+* Configure proper entry points in package.json (main, module, types fields)
+
+* Consider tree-shaking compatibility by using ES modules
+
+* Add proper keywords and description in package.json for discoverability
 "
 `;
 

--- a/packages/builder/src/builder.spec.ts
+++ b/packages/builder/src/builder.spec.ts
@@ -130,6 +130,21 @@ describe("builder", () => {
     expect(response).toMatchSnapshot();
   });
 
+  test("working with cicd system only", async () => {
+    const response = await builder({ cicdSystem: "github-actions" });
+
+    expect(response).toMatchSnapshot();
+  });
+
+  test("working with project type and cicd system", async () => {
+    const response = await builder({
+      projectType: "lib",
+      cicdSystem: "gitlab-ci",
+    });
+
+    expect(response).toMatchSnapshot();
+  });
+
   test("working with all options including framework", async () => {
     const response = await builder({
       language: "typescript",

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -7,6 +7,7 @@ import { frameworkSegment } from "./framework/frameworkSegment";
 import { lintSegment } from "./lint/lintSegment";
 import { releaseSegment } from "./release/releaseSegment";
 import { monorepoSegment } from "./monorepo/monorepoSegment";
+import { cicdSegment } from "./cicd/cicdSegment";
 import { BuilderOptions } from "./BuilderOptions";
 
 export async function builder(options?: BuilderOptions): Promise<string> {
@@ -32,6 +33,7 @@ export async function builder(options?: BuilderOptions): Promise<string> {
     lintSystem,
     releaseSystem,
     monorepoSystem,
+    cicdSystem,
   } = options;
   if (packageManager) {
     tree.children.push({
@@ -49,6 +51,10 @@ export async function builder(options?: BuilderOptions): Promise<string> {
     tree.children = tree.children.concat(
       await monorepoSegment(monorepoSystem)
     );
+  }
+
+  if (cicdSystem) {
+    tree.children = tree.children.concat(await cicdSegment(cicdSystem));
   }
 
   if (language) {

--- a/packages/builder/src/cicd/__snapshots__/cicdSegment.spec.ts.snap
+++ b/packages/builder/src/cicd/__snapshots__/cicdSegment.spec.ts.snap
@@ -1,0 +1,15 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`cicdSegment > returns cicd system line 1`] = `
+[
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "CI/CD system: github-actions",
+      },
+    ],
+    "type": "paragraph",
+  },
+]
+`;

--- a/packages/builder/src/cicd/cicdSegment.spec.ts
+++ b/packages/builder/src/cicd/cicdSegment.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "vitest";
+import { cicdSegment } from "./cicdSegment";
+
+describe("cicdSegment", () => {
+  test("returns cicd system line", async () => {
+    const segment = await cicdSegment("github-actions");
+    expect(segment).toMatchSnapshot();
+  });
+});

--- a/packages/builder/src/cicd/cicdSegment.ts
+++ b/packages/builder/src/cicd/cicdSegment.ts
@@ -1,0 +1,17 @@
+import type { RootContent } from "mdast";
+
+export const cicdSegment = async (system: string): Promise<RootContent[]> => {
+  const segment: RootContent[] = [
+    {
+      type: "paragraph",
+      children: [
+        {
+          type: "text",
+          value: `CI/CD system: ${system}`,
+        },
+      ],
+    },
+  ];
+
+  return segment;
+};

--- a/packages/builder/src/cicd/index.ts
+++ b/packages/builder/src/cicd/index.ts
@@ -1,0 +1,3 @@
+export { CICDSystems, getAvailableCICDSystems } from "./options";
+export type { CICDSystemOption } from "./options";
+export { cicdSegment } from "./cicdSegment";

--- a/packages/builder/src/cicd/options.ts
+++ b/packages/builder/src/cicd/options.ts
@@ -1,0 +1,13 @@
+export interface CICDSystemOption {
+  name: string;
+}
+
+export const CICDSystems: readonly CICDSystemOption[] = [
+  { name: "github-actions" },
+  { name: "gitlab-ci" },
+  { name: "circleci" },
+] as const;
+
+export const getAvailableCICDSystems = (): string[] => {
+  return CICDSystems.map((system) => system.name);
+};

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -12,3 +12,8 @@ export {
   getAvailableMonorepoSystems,
   monorepoSegment,
 } from "./monorepo";
+export {
+  CICDSystems,
+  getAvailableCICDSystems,
+  cicdSegment,
+} from "./cicd";


### PR DESCRIPTION
## Summary
- implement CI/CD segment for builder
- wire CI/CD selection into builder options and builder
- add tests and snapshots for CI/CD segment
- mark TODO item 6 as finished

## Testing
- `pnpm --dir packages/builder test`
- `pnpm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_685026c638e48332a43b0a6e743324d7