### PR TITLE
Add timestamp option to CLI

### DIFF
--- a/apps/cli/src/__tests__/getCreatedAt.spec.ts
+++ b/apps/cli/src/__tests__/getCreatedAt.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { select } from "@inquirer/prompts";
+
+vi.mock("@inquirer/prompts", () => ({
+  select: vi.fn(),
+}));
+
+describe("getCreatedAt", () => {
+  it("prompts user about adding timestamp", async () => {
+    const selectMock = vi.mocked(select);
+    selectMock.mockResolvedValueOnce(true);
+    const { getCreatedAt } = await import("../getCreatedAt");
+
+    const result = await getCreatedAt();
+
+    expect(result).toBe(true);
+    expect(selectMock).toHaveBeenCalledWith({
+      message: "Would you like to add a creation timestamp?",
+      default: false,
+      choices: [
+        { name: "Yes", value: true },
+        { name: "No", value: false },
+        { name: "Skip", value: null },
+      ],
+    });
+  });
+
+  it("returns null when skip is chosen", async () => {
+    const selectMock = vi.mocked(select);
+    selectMock.mockResolvedValueOnce(null);
+    const { getCreatedAt } = await import("../getCreatedAt");
+
+    const result = await getCreatedAt();
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/cli/src/getCreatedAt.ts
+++ b/apps/cli/src/getCreatedAt.ts
@@ -1,0 +1,16 @@
+import { select } from "@inquirer/prompts";
+
+/**
+ * Prompt the user whether to append a creation timestamp.
+ */
+export const getCreatedAt = async (): Promise<boolean | null> => {
+  return select({
+    message: "Would you like to add a creation timestamp?",
+    default: false,
+    choices: [
+      { name: "Yes", value: true },
+      { name: "No", value: false },
+      { name: "Skip", value: null },
+    ],
+  });
+};

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -9,6 +9,7 @@ import { outputPath } from "./outputPath";
 import { getPackageManager } from "./getPackageManager/getPackageManager";
 import { getReleaseSystem } from "./getReleaseSystem";
 import { getMonorepoSystem } from "./getMonorepoSystem";
+import { getCreatedAt } from "./getCreatedAt";
 
 export const main = async () => {
   let builderOptions: BuilderOptions = {};
@@ -45,6 +46,11 @@ export const main = async () => {
     if (framework) {
       builderOptions.framework = framework;
     }
+  }
+
+  const createdAt = await getCreatedAt();
+  if (createdAt !== null) {
+    builderOptions.createdAt = createdAt;
   }
 
   const mdFile = await builder(builderOptions);


### PR DESCRIPTION
## Summary
- prompt for createdAt timestamp in CLI
- include createdAt in generated instructions when not skipped
- test createdAt prompt behavior

## Testing
- `pnpm --filter @vibe-builder/cli lint`
- `pnpm --filter @vibe-builder/cli build`
- `npx vitest run` in `packages/builder`
- `npx vitest run` in `apps/cli`

------
https://chatgpt.com/codex/tasks/task_e_685028c976c48332ad511e020684d743