### PR TITLE
Add e2e project type

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,14 +1,7 @@
 # TODOs
 
 1. [ ] Add lint segment that let you select lint system, The linting system will show you the options according to the language that you choose.
-
-2. [x] Make the ui-lib be a superset of the lib project so when ever the ui-lib is been selected it will also include the lib rules.
-
-3. [ ] Make the publish step for the builder to run in dry run, wait for a dev ik and only then publish the package.
-
-4. [ ] Covert the CI/CD to work with the release system release-it
-
-5. [ ] Add option to add ui framework when choosing ui-lib and its depends on the project framework you choose, for example react will have tailwind and MUI.
-
-6. [x] Add segment for CI/CD framework, like github actions, gitlab ci, circleci, etc. and then add the option to select the CI/CD system in the builder, it will be like the monorepo management system only, without rules.
-7. [ ] Add a project type of e2e testing, it will have the frameworks: playwright and cypress, two rules for now to the e2e testing project will be using of Page object model (POM) and a rule that says to use screenshots testing when possible.
+2. [ ] Make the publish step for the builder to run in dry run, wait for a dev ik and only then publish the package.
+3. [ ] Covert the CI/CD to work with the release system release-it
+4. [ ] Add option to add ui framework when choosing ui-lib and its depends on the project framework you choose, for example react will have tailwind and MUI.
+5. [x] Add a project type of e2e testing, it will have the frameworks: playwright and cypress, two rules for now to the e2e testing project will be using of Page object model (POM) and a rule that says to use screenshots testing when possible.

--- a/packages/builder/src/__snapshots__/builder.spec.ts.snap
+++ b/packages/builder/src/__snapshots__/builder.spec.ts.snap
@@ -133,6 +133,41 @@ Created at: 2020-01-01T00:00:00.000Z
 "
 `;
 
+exports[`builder > working with framework only - cypress 1`] = `
+"# AI agent instructions
+
+## General Guidelines
+
+* Don't work on any of the tasks in the TODO.md file unless you are asked to.
+
+* Always try to early return from functions.
+
+* Use \\\`const\\\` for variables that are not reassigned.
+
+* Make sure to focus on why and not how in documentation.
+
+* Write predictable functions and make a spec file for them according to the testing library in use.
+
+* Don't use \\\`any\\\` in TypeScript, use \\\`unknown\\\` instead.
+
+* Don't cast types without validation.
+
+* Whenever finish a task from the TODO.md file mark it as finished, if there is some that already marked as finish delete them
+
+* Work in a domain driven design (DDD) way, i.e. every function its is own module, and its its folder there is the code with JSDocs, spec file and types in there files.
+
+* Put unit tests in the same folder as the code they test, and name them with \\\`.spec.ts\\\` suffix.
+
+* After finishing the task make sure to run format, lint, test and build commands.
+
+* Don't use file extensions in imports, use absolute imports instead.
+
+## Framework (cypress)
+
+* Use Cypress commands to keep tests concise and readable.
+"
+`;
+
 exports[`builder > working with framework only - nestjs 1`] = `
 "# AI agent instructions
 
@@ -165,6 +200,41 @@ exports[`builder > working with framework only - nestjs 1`] = `
 ## Framework (nestjs)
 
 * Separate the folder structure into domain driven design (DDD) modules, i.e. each module should have its own folder with controllers, services, and entities.
+"
+`;
+
+exports[`builder > working with framework only - playwright 1`] = `
+"# AI agent instructions
+
+## General Guidelines
+
+* Don't work on any of the tasks in the TODO.md file unless you are asked to.
+
+* Always try to early return from functions.
+
+* Use \\\`const\\\` for variables that are not reassigned.
+
+* Make sure to focus on why and not how in documentation.
+
+* Write predictable functions and make a spec file for them according to the testing library in use.
+
+* Don't use \\\`any\\\` in TypeScript, use \\\`unknown\\\` instead.
+
+* Don't cast types without validation.
+
+* Whenever finish a task from the TODO.md file mark it as finished, if there is some that already marked as finish delete them
+
+* Work in a domain driven design (DDD) way, i.e. every function its is own module, and its its folder there is the code with JSDocs, spec file and types in there files.
+
+* Put unit tests in the same folder as the code they test, and name them with \\\`.spec.ts\\\` suffix.
+
+* After finishing the task make sure to run format, lint, test and build commands.
+
+* Don't use file extensions in imports, use absolute imports instead.
+
+## Framework (playwright)
+
+* Prefer using fixtures to share setup across Playwright tests.
 "
 `;
 
@@ -588,6 +658,47 @@ exports[`builder > working with project type and framework - backend with nestjs
 "
 `;
 
+exports[`builder > working with project type and framework - e2e with playwright 1`] = `
+"# AI agent instructions
+
+## General Guidelines
+
+* Don't work on any of the tasks in the TODO.md file unless you are asked to.
+
+* Always try to early return from functions.
+
+* Use \\\`const\\\` for variables that are not reassigned.
+
+* Make sure to focus on why and not how in documentation.
+
+* Write predictable functions and make a spec file for them according to the testing library in use.
+
+* Don't use \\\`any\\\` in TypeScript, use \\\`unknown\\\` instead.
+
+* Don't cast types without validation.
+
+* Whenever finish a task from the TODO.md file mark it as finished, if there is some that already marked as finish delete them
+
+* Work in a domain driven design (DDD) way, i.e. every function its is own module, and its its folder there is the code with JSDocs, spec file and types in there files.
+
+* Put unit tests in the same folder as the code they test, and name them with \\\`.spec.ts\\\` suffix.
+
+* After finishing the task make sure to run format, lint, test and build commands.
+
+* Don't use file extensions in imports, use absolute imports instead.
+
+## Project type (e2e)
+
+* Structure tests using the Page Object Model (POM) for maintainability.
+
+* Use screenshot testing when possible to detect visual regressions.
+
+## Framework (playwright)
+
+* Prefer using fixtures to share setup across Playwright tests.
+"
+`;
+
 exports[`builder > working with project type and framework - frontend with react 1`] = `
 "# AI agent instructions
 
@@ -732,6 +843,43 @@ exports[`builder > working with project type and release system 1`] = `
 ## Release system (semantic-release)
 
 * Use semantic-release for automated versioning and changelog generation.
+"
+`;
+
+exports[`builder > working with project type e2e 1`] = `
+"# AI agent instructions
+
+## General Guidelines
+
+* Don't work on any of the tasks in the TODO.md file unless you are asked to.
+
+* Always try to early return from functions.
+
+* Use \\\`const\\\` for variables that are not reassigned.
+
+* Make sure to focus on why and not how in documentation.
+
+* Write predictable functions and make a spec file for them according to the testing library in use.
+
+* Don't use \\\`any\\\` in TypeScript, use \\\`unknown\\\` instead.
+
+* Don't cast types without validation.
+
+* Whenever finish a task from the TODO.md file mark it as finished, if there is some that already marked as finish delete them
+
+* Work in a domain driven design (DDD) way, i.e. every function its is own module, and its its folder there is the code with JSDocs, spec file and types in there files.
+
+* Put unit tests in the same folder as the code they test, and name them with \\\`.spec.ts\\\` suffix.
+
+* After finishing the task make sure to run format, lint, test and build commands.
+
+* Don't use file extensions in imports, use absolute imports instead.
+
+## Project type (e2e)
+
+* Structure tests using the Page Object Model (POM) for maintainability.
+
+* Use screenshot testing when possible to detect visual regressions.
 "
 `;
 

--- a/packages/builder/src/builder.spec.ts
+++ b/packages/builder/src/builder.spec.ts
@@ -51,6 +51,12 @@ describe("builder", () => {
     expect(response).toMatchSnapshot();
   });
 
+  test("working with project type e2e", async () => {
+    const response = await builder({ projectType: "e2e" });
+
+    expect(response).toMatchSnapshot();
+  });
+
   test("working with project type lib and language typescript", async () => {
     const response = await builder({
       projectType: "lib",
@@ -72,6 +78,18 @@ describe("builder", () => {
     expect(response).toMatchSnapshot();
   });
 
+  test("working with framework only - playwright", async () => {
+    const response = await builder({ framework: "playwright" });
+
+    expect(response).toMatchSnapshot();
+  });
+
+  test("working with framework only - cypress", async () => {
+    const response = await builder({ framework: "cypress" });
+
+    expect(response).toMatchSnapshot();
+  });
+
   test("working with project type and framework - backend with nestjs", async () => {
     const response = await builder({
       projectType: "backend",
@@ -85,6 +103,15 @@ describe("builder", () => {
     const response = await builder({
       projectType: "frontend",
       framework: "react",
+    });
+
+    expect(response).toMatchSnapshot();
+  });
+
+  test("working with project type and framework - e2e with playwright", async () => {
+    const response = await builder({
+      projectType: "e2e",
+      framework: "playwright",
     });
 
     expect(response).toMatchSnapshot();

--- a/packages/builder/src/framework/cypress.ts
+++ b/packages/builder/src/framework/cypress.ts
@@ -1,0 +1,5 @@
+export const cypressRules = [
+  "Use Cypress commands to keep tests concise and readable.",
+] as const;
+
+export type CypressRule = (typeof cypressRules)[number];

--- a/packages/builder/src/framework/frameworkSegment.ts
+++ b/packages/builder/src/framework/frameworkSegment.ts
@@ -1,10 +1,14 @@
 import type { RootContent } from "mdast";
 import { nestjsRules } from "./nestjs";
 import { reactRules } from "./react";
+import { playwrightRules } from "./playwright";
+import { cypressRules } from "./cypress";
 
 const frameworkRulesMap: Record<string, readonly string[]> = {
   nestjs: nestjsRules,
   react: reactRules,
+  playwright: playwrightRules,
+  cypress: cypressRules,
 };
 
 export const frameworkSegment = async (

--- a/packages/builder/src/framework/index.ts
+++ b/packages/builder/src/framework/index.ts
@@ -3,3 +3,5 @@ export { Frameworks, getAvailableFrameworks } from "./options";
 export type { FrameworkOption } from "./options";
 export { nestjsRules } from "./nestjs";
 export { reactRules } from "./react";
+export { playwrightRules } from "./playwright";
+export { cypressRules } from "./cypress";

--- a/packages/builder/src/framework/options.ts
+++ b/packages/builder/src/framework/options.ts
@@ -12,6 +12,14 @@ export const Frameworks: FrameworkOption[] = [
     name: "react",
     availableFor: ["frontend", "ui-lib"],
   },
+  {
+    name: "playwright",
+    availableFor: ["e2e"],
+  },
+  {
+    name: "cypress",
+    availableFor: ["e2e"],
+  },
 ];
 
 export const getAvailableFrameworks = (projectType: string): string[] => {

--- a/packages/builder/src/framework/playwright.ts
+++ b/packages/builder/src/framework/playwright.ts
@@ -1,0 +1,5 @@
+export const playwrightRules = [
+  "Prefer using fixtures to share setup across Playwright tests.",
+] as const;
+
+export type PlaywrightRule = (typeof playwrightRules)[number];

--- a/packages/builder/src/project/__snapshots__/projectSegment.spec.ts.snap
+++ b/packages/builder/src/project/__snapshots__/projectSegment.spec.ts.snap
@@ -1,5 +1,58 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`projectSegment > e2e project returns e2e rules 1`] = `
+[
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "Project type",
+      },
+      {
+        "type": "text",
+        "value": " (e2e)",
+      },
+    ],
+    "depth": 2,
+    "type": "heading",
+  },
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "type": "text",
+                "value": "Structure tests using the Page Object Model (POM) for maintainability.",
+              },
+            ],
+            "type": "paragraph",
+          },
+        ],
+        "type": "listItem",
+      },
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "type": "text",
+                "value": "Use screenshot testing when possible to detect visual regressions.",
+              },
+            ],
+            "type": "paragraph",
+          },
+        ],
+        "type": "listItem",
+      },
+    ],
+    "ordered": false,
+    "type": "list",
+  },
+]
+`;
+
 exports[`projectSegment > ui-lib includes lib rules 1`] = `
 [
   {

--- a/packages/builder/src/project/e2e.ts
+++ b/packages/builder/src/project/e2e.ts
@@ -1,0 +1,6 @@
+export const e2eRules = [
+  "Structure tests using the Page Object Model (POM) for maintainability.",
+  "Use screenshot testing when possible to detect visual regressions.",
+] as const;
+
+export type E2ERule = (typeof e2eRules)[number];

--- a/packages/builder/src/project/index.ts
+++ b/packages/builder/src/project/index.ts
@@ -4,3 +4,4 @@ export * from "./backend";
 export * from "./frontend";
 export * from "./lib";
 export * from "./ui-lib";
+export * from "./e2e";

--- a/packages/builder/src/project/options.ts
+++ b/packages/builder/src/project/options.ts
@@ -8,6 +8,7 @@ export const ProjectTypes: readonly ProjectTypeOption[] = [
   { name: "frontend" },
   { name: "lib" },
   { name: "ui-lib", subset: ["lib"] },
+  { name: "e2e" },
 ] as const;
 
 export type ProjectTypeName = (typeof ProjectTypes)[number]["name"];

--- a/packages/builder/src/project/projectSegment.spec.ts
+++ b/packages/builder/src/project/projectSegment.spec.ts
@@ -6,4 +6,9 @@ describe("projectSegment", () => {
     const segment = await projectSegment("ui-lib");
     expect(segment).toMatchSnapshot();
   });
+
+  test("e2e project returns e2e rules", async () => {
+    const segment = await projectSegment("e2e");
+    expect(segment).toMatchSnapshot();
+  });
 });

--- a/packages/builder/src/project/projectSegment.ts
+++ b/packages/builder/src/project/projectSegment.ts
@@ -3,6 +3,7 @@ import { backendRules } from "./backend";
 import { frontendRules } from "./frontend";
 import { libRules } from "./lib";
 import { uiLibRules } from "./ui-lib";
+import { e2eRules } from "./e2e";
 import { ProjectTypes } from "./options";
 
 const projectRulesMap: Record<string, readonly string[]> = {
@@ -10,6 +11,7 @@ const projectRulesMap: Record<string, readonly string[]> = {
   frontend: frontendRules,
   lib: libRules,
   "ui-lib": uiLibRules,
+  e2e: e2eRules,
 };
 
 export const projectSegment = async (


### PR DESCRIPTION
## Summary
- add new e2e project type with POM and screenshot rules
- expose Playwright and Cypress frameworks for e2e
- update builder logic and tests for new project type
- clean finished items from TODO

## Testing
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6850a3e6df9083328c96c9745b571533