### PR TITLE
Implement testing framework selection in CLI

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,5 +6,5 @@
 4. [ ] Add option to add ui framework when choosing ui-lib and its depends on the project framework you choose, for example react will have tailwind and MUI.
 5. [x] Add a project type of e2e testing, it will have the frameworks: playwright and cypress, two rules for now to the e2e testing project will be using of Page object model (POM) and a rule that says to use screenshots testing when possible.
 6. [ ] Make sure the e2e frameworks can be selected only with an e2e testing project type.
-7. [ ] Add segment to select testing framework, i.e. jest, vitest, mocha.
+7. [x] Add segment to select testing framework, i.e. jest, vitest, mocha.
 8. [ ] Remove the none option if there is a skip option for a cli step

--- a/apps/cli/src/__tests__/getTestFramework.spec.ts
+++ b/apps/cli/src/__tests__/getTestFramework.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { select } from "@inquirer/prompts";
+
+const frameworks = ["jest", "vitest", "mocha"];
+
+vi.mock("@vibe-builder/builder", () => ({
+  getAvailableTestFrameworks: () => frameworks,
+}));
+vi.mock("@inquirer/prompts", () => ({
+  select: vi.fn(),
+}));
+
+describe("getTestFramework", () => {
+  it("prompts user with testing framework options", async () => {
+    const selectMock = vi.mocked(select);
+    selectMock.mockResolvedValueOnce("jest");
+    const { getTestFramework } = await import("../getTestFramework/getTestFramework");
+
+    const result = await getTestFramework();
+
+    expect(result).toBe("jest");
+    expect(selectMock).toHaveBeenCalledWith({
+      message: "Which testing framework would you like to use?",
+      default: null,
+      choices: [
+        { name: "None", value: null },
+        ...frameworks.map((framework) => ({ name: framework, value: framework })),
+        { name: "Skip", value: null },
+      ],
+    });
+  });
+
+  it("returns null when skip is chosen", async () => {
+    const selectMock = vi.mocked(select);
+    selectMock.mockResolvedValueOnce(null);
+    const { getTestFramework } = await import("../getTestFramework/getTestFramework");
+
+    const result = await getTestFramework();
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/cli/src/getTestFramework/getTestFramework.ts
+++ b/apps/cli/src/getTestFramework/getTestFramework.ts
@@ -1,0 +1,22 @@
+import { select } from "@inquirer/prompts";
+import { getAvailableTestFrameworks } from "@vibe-builder/builder";
+
+export const getTestFramework = async () => {
+  const availableFrameworks = getAvailableTestFrameworks();
+
+  if (availableFrameworks.length === 0) {
+    return null;
+  }
+
+  const choices = [
+    { name: "None", value: null },
+    ...availableFrameworks.map((framework) => ({ name: framework, value: framework })),
+    { name: "Skip", value: null },
+  ];
+
+  return select({
+    message: "Which testing framework would you like to use?",
+    default: null,
+    choices,
+  });
+};

--- a/apps/cli/src/getTestFramework/index.ts
+++ b/apps/cli/src/getTestFramework/index.ts
@@ -1,0 +1,1 @@
+export * from './getTestFramework';

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -4,6 +4,7 @@ import { builder, BuilderOptions } from "@vibe-builder/builder";
 import { getLanguage } from "./getLanguage";
 import { getProjectType } from "./getProjectType";
 import { getFramework } from "./getFramework";
+import { getTestFramework } from "./getTestFramework";
 import { getLintSystem } from "./getLintSystem";
 import { outputPath } from "./outputPath";
 import { getPackageManager } from "./getPackageManager/getPackageManager";
@@ -46,6 +47,11 @@ export const main = async () => {
     if (framework) {
       builderOptions.framework = framework;
     }
+  }
+
+  const testFramework = await getTestFramework();
+  if (testFramework) {
+    builderOptions.testFramework = testFramework;
   }
 
   const createdAt = await getCreatedAt();

--- a/packages/builder/src/BuilderOptions.spec.ts
+++ b/packages/builder/src/BuilderOptions.spec.ts
@@ -60,6 +60,13 @@ describe("BuilderOptions", () => {
       cicdSystem: "gitlab-ci",
     });
   });
+  it("should accept testFramework without restrictions", () => {
+    assertType<BuilderOptions>({ testFramework: "jest" });
+    assertType<BuilderOptions>({
+      projectType: "lib",
+      testFramework: "vitest",
+    });
+  });
   it("should accept createdAt option", () => {
     assertType<BuilderOptions>({ createdAt: true });
   });

--- a/packages/builder/src/BuilderOptions.ts
+++ b/packages/builder/src/BuilderOptions.ts
@@ -1,6 +1,7 @@
 type BaseBuilderOptions = {
   projectType?: string;
   framework?: string;
+  testFramework?: string;
   releaseSystem?: string;
   monorepoSystem?: string;
   cicdSystem?: string;

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -4,6 +4,7 @@ import { generalSegment } from "./general/generalSegment";
 import { languageSegment } from "./language/languageSegment";
 import { projectSegment } from "./project/projectSegment";
 import { frameworkSegment } from "./framework/frameworkSegment";
+import { testingSegment } from "./testing/testingSegment";
 import { lintSegment } from "./lint/lintSegment";
 import { releaseSegment } from "./release/releaseSegment";
 import { monorepoSegment } from "./monorepo/monorepoSegment";
@@ -31,6 +32,7 @@ export async function builder(options?: BuilderOptions): Promise<string> {
     packageManager,
     projectType,
     framework,
+    testFramework,
     lintSystem,
     releaseSystem,
     monorepoSystem,
@@ -70,6 +72,10 @@ export async function builder(options?: BuilderOptions): Promise<string> {
 
   if (framework) {
     tree.children = tree.children.concat(await frameworkSegment(framework));
+  }
+
+  if (testFramework) {
+    tree.children = tree.children.concat(await testingSegment(testFramework));
   }
 
   if (releaseSystem) {

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -5,6 +5,7 @@ export { Languages } from "./language";
 export { ProjectTypes } from "./project";
 export { LintSystems, getAvailableLintSystems } from "./lint";
 export { lintSegment } from "./lint";
+export { TestingFrameworks, getAvailableTestFrameworks, testingSegment } from "./testing";
 export { ReleaseSystems, getAvailableReleaseSystems } from "./release";
 export { releaseSegment } from "./release";
 export {

--- a/packages/builder/src/testing/__snapshots__/testingSegment.spec.ts.snap
+++ b/packages/builder/src/testing/__snapshots__/testingSegment.spec.ts.snap
@@ -1,0 +1,40 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`testingSegment > returns testing framework guidelines 1`] = `
+[
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "Testing framework",
+      },
+      {
+        "type": "text",
+        "value": " (jest)",
+      },
+    ],
+    "depth": 2,
+    "type": "heading",
+  },
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "type": "text",
+                "value": "Use Jest for fast and comprehensive unit testing.",
+              },
+            ],
+            "type": "paragraph",
+          },
+        ],
+        "type": "listItem",
+      },
+    ],
+    "ordered": false,
+    "type": "list",
+  },
+]
+`;

--- a/packages/builder/src/testing/index.ts
+++ b/packages/builder/src/testing/index.ts
@@ -1,0 +1,6 @@
+export { TestingFrameworks, getAvailableTestFrameworks } from "./options";
+export type { TestingFrameworkOption } from "./options";
+export { testingSegment } from "./testingSegment";
+export { jestRules } from "./jest";
+export { vitestRules } from "./vitest";
+export { mochaRules } from "./mocha";

--- a/packages/builder/src/testing/jest.ts
+++ b/packages/builder/src/testing/jest.ts
@@ -1,0 +1,5 @@
+export const jestRules = [
+  "Use Jest for fast and comprehensive unit testing.",
+] as const;
+
+export type JestRule = (typeof jestRules)[number];

--- a/packages/builder/src/testing/mocha.ts
+++ b/packages/builder/src/testing/mocha.ts
@@ -1,0 +1,5 @@
+export const mochaRules = [
+  "Use Mocha for flexible asynchronous testing.",
+] as const;
+
+export type MochaRule = (typeof mochaRules)[number];

--- a/packages/builder/src/testing/options.ts
+++ b/packages/builder/src/testing/options.ts
@@ -1,0 +1,13 @@
+export interface TestingFrameworkOption {
+  name: string;
+}
+
+export const TestingFrameworks: readonly TestingFrameworkOption[] = [
+  { name: "jest" },
+  { name: "vitest" },
+  { name: "mocha" },
+] as const;
+
+export const getAvailableTestFrameworks = (): string[] => {
+  return TestingFrameworks.map((f) => f.name);
+};

--- a/packages/builder/src/testing/testingSegment.spec.ts
+++ b/packages/builder/src/testing/testingSegment.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "vitest";
+import { testingSegment } from "./testingSegment";
+
+describe("testingSegment", () => {
+  test("returns testing framework guidelines", async () => {
+    const segment = await testingSegment("jest");
+    expect(segment).toMatchSnapshot();
+  });
+});

--- a/packages/builder/src/testing/testingSegment.ts
+++ b/packages/builder/src/testing/testingSegment.ts
@@ -1,0 +1,41 @@
+import type { ListItem, RootContent } from "mdast";
+import { jestRules } from "./jest";
+import { vitestRules } from "./vitest";
+import { mochaRules } from "./mocha";
+
+const testingRulesMap: Record<string, readonly string[]> = {
+  jest: jestRules,
+  vitest: vitestRules,
+  mocha: mochaRules,
+};
+
+export const testingSegment = async (
+  framework: string
+): Promise<RootContent[]> => {
+  const testItems = testingRulesMap[framework] ?? [];
+
+  const segment: RootContent[] = [
+    {
+      type: "heading",
+      depth: 2,
+      children: [
+        { type: "text", value: "Testing framework" },
+        { type: "text", value: ` (${framework})` },
+      ],
+    },
+    {
+      type: "list",
+      ordered: false,
+      children: testItems.map(
+        (item: string): ListItem => ({
+          type: "listItem",
+          children: [
+            { type: "paragraph", children: [{ type: "text", value: item }] },
+          ],
+        })
+      ),
+    },
+  ];
+
+  return segment;
+};

--- a/packages/builder/src/testing/vitest.ts
+++ b/packages/builder/src/testing/vitest.ts
@@ -1,0 +1,5 @@
+export const vitestRules = [
+  "Use Vitest for Vite-powered projects and fast test execution.",
+] as const;
+
+export type VitestRule = (typeof vitestRules)[number];


### PR DESCRIPTION
## Summary
- enable choosing a testing framework when running the CLI
- support test framework segment in the builder
- document option in BuilderOptions
- add related unit tests and snapshots
- mark TODO as done

## Testing
- `pnpm lint` *(fails: command not found or network issue)*
- `pnpm test` *(fails: command not found or network issue)*

------
https://chatgpt.com/codex/tasks/task_e_685194f67eec833282cf3b7eba904be9