### PR TITLE
Update CLI options to remove None when Skip is present

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@
 2. [ ] Make the publish step for the builder to run in dry run, wait for a dev ik and only then publish the package.
 3. [ ] Covert the CI/CD to work with the release system release-it
 4. [ ] Add option to add ui framework when choosing ui-lib and its depends on the project framework you choose, for example react will have tailwind and MUI.
-5. [x] Add a project type of e2e testing, it will have the frameworks: playwright and cypress, two rules for now to the e2e testing project will be using of Page object model (POM) and a rule that says to use screenshots testing when possible.
-6. [ ] Make sure the e2e frameworks can be selected only with an e2e testing project type.
-7. [ ] Add segment to select testing framework, i.e. jest, vitest, mocha.
-8. [ ] Remove the none option if there is a skip option for a cli step
+5. [ ] Make sure the e2e frameworks can be selected only with an e2e testing project type.
+6. [ ] Add segment to select testing framework, i.e. jest, vitest, mocha.
+7. [x] Remove the none option if there is a skip option for a cli step

--- a/apps/cli/TODO.md
+++ b/apps/cli/TODO.md
@@ -4,12 +4,9 @@
 
 2. [ ] Add to the CI running lint, test and build steps for the cli as like the builder
 
-3. [x] Add option to select monorepo management system.
+3. [ ] Add publish step to the CI, the same as the builder.
 
-4. [ ] Add publish step to the CI, the same as the builder.
+4. [ ] Add option to add ui framework when choosing ui-lib and its depends on the project framework you choose, for example react will have tailwind and MUI.
 
-5. [ ] Add option to add ui framework when choosing ui-lib and its depends on the project framework you choose, for example react will have tailwind and MUI.
-
-6. [x] Add option to skip to all segments.
-7. [ ] Make pnpm the default package manager for the cli and lowercase all the options of the package managers.
-8. [ ] Add the e2e project to be an option in the cli.
+5. [ ] Make pnpm the default package manager for the cli and lowercase all the options of the package managers.
+6. [ ] Add the e2e project to be an option in the cli.

--- a/apps/cli/src/__tests__/getMonorepoSystem.spec.ts
+++ b/apps/cli/src/__tests__/getMonorepoSystem.spec.ts
@@ -23,7 +23,6 @@ describe("getMonorepoSystem", () => {
       message: "Which monorepo system would you like to use?",
       default: null,
       choices: [
-        { name: "None", value: null },
         ...systems.map((system) => ({ name: system, value: system })),
         { name: "Skip", value: null },
       ],

--- a/apps/cli/src/getFramework.ts
+++ b/apps/cli/src/getFramework.ts
@@ -9,7 +9,6 @@ export const getFramework = async (projectType: string) => {
   }
 
   const choices = [
-    { name: "None", value: null },
     ...availableFrameworks.map((framework) => ({
       name: framework,
       value: framework,

--- a/apps/cli/src/getLintSystem.ts
+++ b/apps/cli/src/getLintSystem.ts
@@ -9,7 +9,6 @@ export const getLintSystem = async (language: string) => {
   }
 
   const choices = [
-    { name: "None", value: null },
     ...available.map((lint) => ({ name: lint, value: lint })),
     { name: "Skip", value: null },
   ];

--- a/apps/cli/src/getMonorepoSystem.ts
+++ b/apps/cli/src/getMonorepoSystem.ts
@@ -9,7 +9,6 @@ export const getMonorepoSystem = async () => {
   }
 
   const choices = [
-    { name: "None", value: null },
     ...availableSystems.map((system) => ({ name: system, value: system })),
     { name: "Skip", value: null },
   ];

--- a/packages/builder/TODO.md
+++ b/packages/builder/TODO.md
@@ -2,7 +2,3 @@
 
 1. [ ] Add test that validate that only libs projects can have release system, validate that the types are type-safe as well.
 
-2. [x] Fix the CI/CD to publish this package to npm.
-
-3. [x] Add the option to add "create at" timestamp to the generated files, it will be in the end of the file and will be optional, add snapshot tests for this feature.
-4. [x] Add default rules so for example no matter which cicd system im choosing i will always get the rules that a ci process should have lint, test, build and the rule that says that the cd process should use the release system that define for the project.


### PR DESCRIPTION
## Summary
- refine CLI choice lists to exclude `None` when a `Skip` option exists
- update monorepo system tests for new option list
- cleanup completed TODO items

## Testing
- `pnpm test` *(fails: ENETUNREACH while fetching pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_685194eeefb483329c636d7ca3fb8c71