### PR TITLE
Complete task 9 in cli TODO

### DIFF
--- a/apps/cli/TODO.md
+++ b/apps/cli/TODO.md
@@ -12,4 +12,5 @@
 6. [ ] Add the e2e project to be an option in the cli.
 7. [x] Remove the **test** folder and put the tests where they belong.
 8. [ ] Add the option to choose e2e project.
-9. [ ] Make the option to choose the testing framework depend on the project type that the user chooses, for example if the user chooses lib then the testing framework will be vitest or jest, if the user chooses e2e then the testing framework will be cypress or playwright, if the user chooses app then the testing framework will be vitest or jest.
+9. [x] Make the option to choose the testing framework depend on the project type that the user chooses, for example if the user chooses lib then the testing framework will be vitest or jest, if the user chooses e2e then the testing framework will be cypress or playwright, if the user chooses app then the testing framework will be vitest or jest.
+

--- a/apps/cli/src/__tests__/getTestingFramework.spec.ts
+++ b/apps/cli/src/__tests__/getTestingFramework.spec.ts
@@ -3,18 +3,19 @@ import { select } from "@inquirer/prompts";
 
 vi.mock("@vibe-builder/builder", () => ({
   getAvailableTestingFrameworks: () => ["jest", "vitest", "mocha"],
+  getAvailableFrameworks: () => ["cypress", "playwright"],
 }));
 vi.mock("@inquirer/prompts", () => ({
   select: vi.fn(),
 }));
 
 describe("getTestingFramework", () => {
-  it("prompts user with testing framework options", async () => {
+  it("prompts user with testing framework options for lib", async () => {
     const selectMock = vi.mocked(select);
     selectMock.mockResolvedValueOnce("jest");
     const { getTestingFramework } = await import("../getTestingFramework");
 
-    const result = await getTestingFramework();
+    const result = await getTestingFramework("lib");
 
     expect(result).toBe("jest");
     expect(selectMock).toHaveBeenCalledWith({
@@ -24,7 +25,26 @@ describe("getTestingFramework", () => {
         { name: "None", value: null },
         { name: "jest", value: "jest" },
         { name: "vitest", value: "vitest" },
-        { name: "mocha", value: "mocha" },
+        { name: "Skip", value: null },
+      ],
+    });
+  });
+
+  it("prompts user with testing framework options for e2e", async () => {
+    const selectMock = vi.mocked(select);
+    selectMock.mockResolvedValueOnce("cypress");
+    const { getTestingFramework } = await import("../getTestingFramework");
+
+    const result = await getTestingFramework("e2e");
+
+    expect(result).toBe("cypress");
+    expect(selectMock).toHaveBeenCalledWith({
+      message: "Which testing framework would you like to use?",
+      default: null,
+      choices: [
+        { name: "None", value: null },
+        { name: "cypress", value: "cypress" },
+        { name: "playwright", value: "playwright" },
         { name: "Skip", value: null },
       ],
     });
@@ -35,7 +55,7 @@ describe("getTestingFramework", () => {
     selectMock.mockResolvedValueOnce(null);
     const { getTestingFramework } = await import("../getTestingFramework");
 
-    const result = await getTestingFramework();
+    const result = await getTestingFramework("lib");
 
     expect(result).toBeNull();
   });

--- a/apps/cli/src/getTestingFramework.ts
+++ b/apps/cli/src/getTestingFramework.ts
@@ -1,8 +1,16 @@
 import { select } from "@inquirer/prompts";
-import { getAvailableTestingFrameworks } from "@vibe-builder/builder";
+import {
+  getAvailableFrameworks,
+  getAvailableTestingFrameworks,
+} from "@vibe-builder/builder";
 
-export const getTestingFramework = async () => {
-  const available = getAvailableTestingFrameworks();
+export const getTestingFramework = async (projectType: string) => {
+  const available =
+    projectType === "e2e"
+      ? getAvailableFrameworks("e2e")
+      : getAvailableTestingFrameworks().filter((framework) =>
+          ["jest", "vitest"].includes(framework)
+        );
 
   const choices = [
     { name: "None", value: null },

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -21,11 +21,17 @@ export const main = async () => {
       language,
       packageManager: (await getPackageManager(language)) ?? undefined,
       lintSystem: (await getLintSystem(language)) ?? undefined,
-      testFramework: (await getTestingFramework()) ?? undefined,
     };
   }
 
-  builderOptions.projectType = await getProjectType() ?? undefined;
+  builderOptions.projectType = (await getProjectType()) ?? undefined;
+
+  if (builderOptions.projectType) {
+    const testing = await getTestingFramework(builderOptions.projectType);
+    if (testing) {
+      builderOptions.testFramework = testing;
+    }
+  }
 
   if (
     builderOptions.projectType &&


### PR DESCRIPTION
## Summary
- filter testing framework choices based on project type
- update CLI workflow to ask for testing framework after project type
- update specs for getTestingFramework
- mark TODO item as done

## Testing
- `pnpm i`
- `pnpm exec turbo test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/latest)*
- `pnpm exec turbo lint` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_6851c9e2eadc83328dfebb89825e9a94