### PR TITLE
Add general UI rules

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,4 +6,4 @@
 4. [ ] Add option to add ui framework when choosing ui-lib and its depends on the project framework you choose, for example react will have tailwind and MUI.
 5. [ ] Make sure the e2e frameworks can be selected only with an e2e testing project type.
 6. [ ] Add segment to select testing framework, i.e. jest, vitest, mocha.
-7. [ ] Make General UI rules that will be applied every time the project is relevant for example if it a frontend, ui-lib at the moment the only rule is "Write styling in a direction agnostic way: i.e. use start and end instead of left and right".
+7. [x] Make General UI rules that will be applied every time the project is relevant for example if it a frontend, ui-lib at the moment the only rule is "Write styling in a direction agnostic way: i.e. use start and end instead of left and right".

--- a/packages/builder/src/__snapshots__/builder.spec.ts.snap
+++ b/packages/builder/src/__snapshots__/builder.spec.ts.snap
@@ -57,6 +57,10 @@ Package Manager: npm
 
 * When writing a component, try to enter logic or network into it.
 
+## General UI Guidelines
+
+* Write styling in a direction agnostic way: i.e. use start and end instead of left and right
+
 ## Framework (react)
 
 * Use key in React lists to help React identify which items have changed, are added, or removed.
@@ -738,6 +742,10 @@ exports[`builder > working with project type and framework - frontend with react
 
 * When writing a component, try to enter logic or network into it.
 
+## General UI Guidelines
+
+* Write styling in a direction agnostic way: i.e. use start and end instead of left and right
+
 ## Framework (react)
 
 * Use key in React lists to help React identify which items have changed, are added, or removed.
@@ -1033,6 +1041,10 @@ exports[`builder > working with project type only 1`] = `
 * Use rems for font sizes and spacing to ensure scalability.
 
 * When writing a component, try to enter logic or network into it.
+
+## General UI Guidelines
+
+* Write styling in a direction agnostic way: i.e. use start and end instead of left and right
 "
 `;
 
@@ -1099,6 +1111,10 @@ exports[`builder > working with project type ui-lib 1`] = `
 * Consider tree-shaking compatibility by using ES modules
 
 * Add proper keywords and description in package.json for discoverability
+
+## General UI Guidelines
+
+* Write styling in a direction agnostic way: i.e. use start and end instead of left and right
 "
 `;
 

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -73,6 +73,8 @@ export async function builder(options?: BuilderOptions): Promise<string> {
 
   if (projectType) {
     tree.children = tree.children.concat(await projectSegment(projectType));
+
+    // Extract to function and add spec `toIncludeUIGuidelines`
     if (projectType === "frontend" || projectType === "ui-lib") {
       tree.children = tree.children.concat(await uiSegment());
     }

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -11,6 +11,7 @@ import { cicdSegment } from "./cicd/cicdSegment";
 import { BuilderOptions } from "./BuilderOptions";
 import { createdAtSegment } from "./createdAt/createdAtSegment";
 import { testingSegment } from "./testing/testingSegment";
+import { uiSegment } from "./ui/uiSegment";
 
 export async function builder(options?: BuilderOptions): Promise<string> {
   const tree: Root = {
@@ -72,6 +73,9 @@ export async function builder(options?: BuilderOptions): Promise<string> {
 
   if (projectType) {
     tree.children = tree.children.concat(await projectSegment(projectType));
+    if (projectType === "frontend" || projectType === "ui-lib") {
+      tree.children = tree.children.concat(await uiSegment());
+    }
   }
 
   if (framework) {

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -19,3 +19,4 @@ export {
   getAvailableTestingFrameworks,
   testingSegment,
 } from "./testing";
+export { uiSegment } from "./ui/uiSegment";

--- a/packages/builder/src/ui/__snapshots__/uiSegment.spec.ts.snap
+++ b/packages/builder/src/ui/__snapshots__/uiSegment.spec.ts.snap
@@ -1,0 +1,30 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`uiSegment > returns general ui guidelines 1`] = `
+[
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "General UI Guidelines",
+      },
+    ],
+    "depth": 2,
+    "type": "heading",
+  },
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "type": "text",
+            "value": "Write styling in a direction agnostic way: i.e. use start and end instead of left and right",
+          },
+        ],
+        "type": "paragraph",
+      },
+    ],
+    "type": "listItem",
+  },
+]
+`;

--- a/packages/builder/src/ui/rules.ts
+++ b/packages/builder/src/ui/rules.ts
@@ -1,0 +1,5 @@
+export const uiRules = [
+  "Write styling in a direction agnostic way: i.e. use start and end instead of left and right",
+] as const;
+
+export type UIRule = (typeof uiRules)[number];

--- a/packages/builder/src/ui/uiSegment.spec.ts
+++ b/packages/builder/src/ui/uiSegment.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "vitest";
+import { uiSegment } from "./uiSegment";
+
+describe("uiSegment", () => {
+  test("returns general ui guidelines", async () => {
+    const segment = await uiSegment();
+    expect(segment).toMatchSnapshot();
+  });
+});

--- a/packages/builder/src/ui/uiSegment.ts
+++ b/packages/builder/src/ui/uiSegment.ts
@@ -1,0 +1,21 @@
+import type { ListItem, RootContent } from "mdast";
+import { uiRules } from "./rules";
+
+export const uiSegment = async (): Promise<RootContent[]> => {
+  const segment: RootContent[] = [
+    {
+      type: "heading",
+      depth: 2,
+      children: [{ type: "text", value: "General UI Guidelines" }],
+    },
+    ...uiRules.map(
+      (rule): ListItem => ({
+        type: "listItem",
+        children: [
+          { type: "paragraph", children: [{ type: "text", value: rule }] },
+        ],
+      })
+    ),
+  ];
+  return segment;
+};


### PR DESCRIPTION
## Summary
- implement new `ui` segment with direction-agnostic styling guideline
- use the segment automatically for frontend and ui-lib projects
- export new segment
- update tests and snapshots
- mark related TODO as complete

## Testing
- `pnpm --filter @vibe-builder/builder lint`
- `pnpm --filter @vibe-builder/builder test`
- `pnpm --filter @vibe-builder/builder build`
- `pnpm lint` *(fails: tsc errors in cli)*
- `pnpm test` *(fails: corepack network issues)*
- `pnpm build` *(fails: corepack network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6851f34a1b848332964f9e154e729a96