### PR TITLE
Add e2ePreferences CLI segment

### DIFF
--- a/apps/cli/TODO.md
+++ b/apps/cli/TODO.md
@@ -9,6 +9,6 @@
 4. [ ] Add option to add ui framework when choosing ui-lib and its depends on the project framework you choose, for example react will have tailwind and MUI.
 
 5. [ ] Make pnpm the default package manager for the cli and lowercase all the options of the package managers.
-6. [ ] Add the e2e project to be an option in the cli.
-7. [ ] Add the option to choose e2e project.
+6. [x] Add the e2e project to be an option in the cli.
+7. [x] Add the option to choose e2e project.
 

--- a/apps/cli/src/e2ePreferences.spec.ts
+++ b/apps/cli/src/e2ePreferences.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { select } from "@inquirer/prompts";
+
+vi.mock("@inquirer/prompts", () => ({
+  select: vi.fn(),
+}));
+
+import { e2ePreferences } from "./e2ePreferences";
+
+describe("e2ePreferences", () => {
+  it("prompts user with network mocking options", async () => {
+    const selectMock = vi.mocked(select);
+    selectMock.mockResolvedValueOnce("msw");
+
+    const result = await e2ePreferences();
+
+    expect(result).toBe("msw");
+    expect(selectMock).toHaveBeenCalledWith({
+      message: "How do you prefer to mock network requests?",
+      default: "msw",
+      choices: [
+        { name: "MSW", value: "msw" },
+        { name: "Route Interception", value: "route-interception" },
+        { name: "Skip", value: null },
+      ],
+    });
+  });
+
+  it("returns null when skip is chosen", async () => {
+    const selectMock = vi.mocked(select);
+    selectMock.mockResolvedValueOnce(null);
+
+    const result = await e2ePreferences();
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/cli/src/e2ePreferences.ts
+++ b/apps/cli/src/e2ePreferences.ts
@@ -1,0 +1,16 @@
+import { select } from "@inquirer/prompts";
+
+/**
+ * Ask the user how to mock network requests during e2e tests.
+ */
+export const e2ePreferences = async (): Promise<"msw" | "route-interception" | null> => {
+  return select({
+    message: "How do you prefer to mock network requests?",
+    default: "msw",
+    choices: [
+      { name: "MSW", value: "msw" },
+      { name: "Route Interception", value: "route-interception" },
+      { name: "Skip", value: null },
+    ],
+  });
+};

--- a/apps/cli/src/getCreatedAt.spec.ts
+++ b/apps/cli/src/getCreatedAt.spec.ts
@@ -9,7 +9,7 @@ describe("getCreatedAt", () => {
   it("prompts user about adding timestamp", async () => {
     const selectMock = vi.mocked(select);
     selectMock.mockResolvedValueOnce(true);
-    const { getCreatedAt } = await import("../getCreatedAt");
+    const { getCreatedAt } = await import("./getCreatedAt");
 
     const result = await getCreatedAt();
 
@@ -28,7 +28,7 @@ describe("getCreatedAt", () => {
   it("returns null when skip is chosen", async () => {
     const selectMock = vi.mocked(select);
     selectMock.mockResolvedValueOnce(null);
-    const { getCreatedAt } = await import("../getCreatedAt");
+    const { getCreatedAt } = await import("./getCreatedAt");
 
     const result = await getCreatedAt();
 

--- a/apps/cli/src/getLanguage.spec.ts
+++ b/apps/cli/src/getLanguage.spec.ts
@@ -13,7 +13,7 @@ describe("getLanguage", () => {
   it("returns null when skip is chosen", async () => {
     const selectMock = vi.mocked(select);
     selectMock.mockResolvedValueOnce(null);
-    const { getLanguage } = await import("../getLanguage");
+    const { getLanguage } = await import("./getLanguage");
     const result = await getLanguage();
     expect(result).toBeNull();
   });

--- a/apps/cli/src/getMonorepoSystem.spec.ts
+++ b/apps/cli/src/getMonorepoSystem.spec.ts
@@ -14,7 +14,7 @@ describe("getMonorepoSystem", () => {
   it("prompts user with monorepo system options", async () => {
     const selectMock = vi.mocked(select);
     selectMock.mockResolvedValueOnce("nx");
-    const { getMonorepoSystem } = await import("../getMonorepoSystem");
+    const { getMonorepoSystem } = await import("./getMonorepoSystem");
 
     const result = await getMonorepoSystem();
 
@@ -32,7 +32,7 @@ describe("getMonorepoSystem", () => {
   it("returns null when skip is chosen", async () => {
     const selectMock = vi.mocked(select);
     selectMock.mockResolvedValueOnce(null);
-    const { getMonorepoSystem } = await import("../getMonorepoSystem");
+    const { getMonorepoSystem } = await import("./getMonorepoSystem");
 
     const result = await getMonorepoSystem();
 

--- a/apps/cli/src/getProjectType/getProjectType.spec.ts
+++ b/apps/cli/src/getProjectType/getProjectType.spec.ts
@@ -37,4 +37,13 @@ describe("getProjectType", () => {
 
     expect(result).toBeNull();
   });
+
+  it("returns e2e when selected", async () => {
+    const selectMock = vi.mocked(select);
+    selectMock.mockResolvedValueOnce("e2e");
+
+    const result = await getProjectType();
+
+    expect(result).toBe("e2e");
+  });
 });

--- a/apps/cli/src/getProjectType/types.ts
+++ b/apps/cli/src/getProjectType/types.ts
@@ -1,3 +1,9 @@
-export const projectTypes = ["backend", "frontend", "lib", "ui-lib"] as const;
+export const projectTypes = [
+  "backend",
+  "frontend",
+  "lib",
+  "ui-lib",
+  "e2e",
+] as const;
 
 export type ProjectType = (typeof projectTypes)[number];

--- a/apps/cli/src/getReleaseSystem.spec.ts
+++ b/apps/cli/src/getReleaseSystem.spec.ts
@@ -14,7 +14,7 @@ describe("getReleaseSystem", () => {
   it("prompts user with release system options", async () => {
     const selectMock = vi.mocked(select);
     selectMock.mockResolvedValueOnce("release-it");
-    const { getReleaseSystem } = await import("../getReleaseSystem");
+    const { getReleaseSystem } = await import("./getReleaseSystem");
 
     const result = await getReleaseSystem();
 
@@ -32,7 +32,7 @@ describe("getReleaseSystem", () => {
   it("returns null when skip is chosen", async () => {
     const selectMock = vi.mocked(select);
     selectMock.mockResolvedValueOnce(null);
-    const { getReleaseSystem } = await import("../getReleaseSystem");
+    const { getReleaseSystem } = await import("./getReleaseSystem");
 
     const result = await getReleaseSystem();
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -11,6 +11,7 @@ import { getPackageManager } from "./getPackageManager/getPackageManager";
 import { getReleaseSystem } from "./getReleaseSystem";
 import { getMonorepoSystem } from "./getMonorepoSystem";
 import { getCreatedAt } from "./getCreatedAt";
+import { e2ePreferences } from "./e2ePreferences";
 
 export const main = async () => {
   let builderOptions: BuilderOptions = {};
@@ -30,6 +31,9 @@ export const main = async () => {
     const testing = await getTestingFramework(builderOptions.projectType);
     if (testing) {
       builderOptions.testFramework = testing;
+    }
+    if (builderOptions.projectType === "e2e") {
+      await e2ePreferences();
     }
   }
 


### PR DESCRIPTION
## Summary
- create `e2ePreferences` CLI prompt
- test new prompt
- call `e2ePreferences` when e2e project type is selected
- fix import paths in CLI tests

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855d97e2db483329e55520fc8db5357