### PR TITLE
Add network mocking to builder

### DIFF
--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -33,7 +33,10 @@ export const main = async () => {
       builderOptions.testFramework = testing;
     }
     if (builderOptions.projectType === "e2e") {
-      await e2ePreferences();
+      const networkMocking = await e2ePreferences();
+      if (networkMocking) {
+        builderOptions.networkMocking = networkMocking;
+      }
     }
   }
 

--- a/packages/builder/src/BuilderOptions.ts
+++ b/packages/builder/src/BuilderOptions.ts
@@ -6,6 +6,7 @@ type BaseBuilderOptions = {
   cicdSystem?: string;
   createdAt?: boolean;
   testFramework?: string;
+  networkMocking?: string;
 };
 type BuilderOptionsWithLanguage = {
   language: string;

--- a/packages/builder/src/__snapshots__/builder.spec.ts.snap
+++ b/packages/builder/src/__snapshots__/builder.spec.ts.snap
@@ -841,7 +841,7 @@ exports[`builder > working with project type and framework - e2e with playwright
 
 * Use screenshot testing when possible to detect visual regressions.
 
-* Use msw (Mock Service Worker) for API mocking in tests to ensure consistent and reliable test environments.
+Network mocking: msw
 
 ## Framework (playwright)
 
@@ -1067,7 +1067,7 @@ exports[`builder > working with project type e2e 1`] = `
 
 * Use screenshot testing when possible to detect visual regressions.
 
-* Use msw (Mock Service Worker) for API mocking in tests to ensure consistent and reliable test environments.
+Network mocking: msw
 "
 `;
 

--- a/packages/builder/src/builder.spec.ts
+++ b/packages/builder/src/builder.spec.ts
@@ -52,7 +52,7 @@ describe("builder", () => {
   });
 
   test("working with project type e2e", async () => {
-    const response = await builder({ projectType: "e2e" });
+    const response = await builder({ projectType: "e2e", networkMocking: "msw" });
 
     expect(response).toMatchSnapshot();
   });
@@ -112,6 +112,7 @@ describe("builder", () => {
     const response = await builder({
       projectType: "e2e",
       framework: "playwright",
+      networkMocking: "msw",
     });
 
     expect(response).toMatchSnapshot();

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -12,6 +12,7 @@ import { BuilderOptions } from "./BuilderOptions";
 import { createdAtSegment } from "./createdAt/createdAtSegment";
 import { testingSegment } from "./testing/testingSegment";
 import { uiSegment } from "./ui/uiSegment";
+import { networkMockingSegment } from "./networkMocking/networkMockingSegment";
 
 export async function builder(options?: BuilderOptions): Promise<string> {
   const tree: Root = {
@@ -39,6 +40,7 @@ export async function builder(options?: BuilderOptions): Promise<string> {
     monorepoSystem,
     cicdSystem,
     createdAt,
+    networkMocking,
   } = options;
   if (packageManager) {
     tree.children.push({
@@ -77,6 +79,11 @@ export async function builder(options?: BuilderOptions): Promise<string> {
     // Extract to function and add spec `toIncludeUIGuidelines`
     if (projectType === "frontend" || projectType === "ui-lib") {
       tree.children = tree.children.concat(await uiSegment());
+    }
+    if (projectType === "e2e" && networkMocking) {
+      tree.children = tree.children.concat(
+        await networkMockingSegment(networkMocking)
+      );
     }
   }
 

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -20,3 +20,4 @@ export {
   testingSegment,
 } from "./testing";
 export { uiSegment } from "./ui/uiSegment";
+export { networkMockingSegment } from "./networkMocking";

--- a/packages/builder/src/networkMocking/__snapshots__/networkMockingSegment.spec.ts.snap
+++ b/packages/builder/src/networkMocking/__snapshots__/networkMockingSegment.spec.ts.snap
@@ -1,0 +1,15 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`networkMockingSegment > returns network mocking line 1`] = `
+[
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "Network mocking: msw",
+      },
+    ],
+    "type": "paragraph",
+  },
+]
+`;

--- a/packages/builder/src/networkMocking/index.ts
+++ b/packages/builder/src/networkMocking/index.ts
@@ -1,0 +1,1 @@
+export { networkMockingSegment } from "./networkMockingSegment";

--- a/packages/builder/src/networkMocking/networkMockingSegment.spec.ts
+++ b/packages/builder/src/networkMocking/networkMockingSegment.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "vitest";
+import { networkMockingSegment } from "./networkMockingSegment";
+
+describe("networkMockingSegment", () => {
+  test("returns network mocking line", async () => {
+    const segment = await networkMockingSegment("msw");
+    expect(segment).toMatchSnapshot();
+  });
+});

--- a/packages/builder/src/networkMocking/networkMockingSegment.ts
+++ b/packages/builder/src/networkMocking/networkMockingSegment.ts
@@ -1,0 +1,20 @@
+import type { RootContent } from "mdast";
+
+/**
+ * Generate a line describing how network requests should be mocked.
+ *
+ * @param method - chosen mocking method
+ * @returns markdown AST nodes representing the instruction
+ */
+export const networkMockingSegment = async (
+  method: string
+): Promise<RootContent[]> => {
+  const segment: RootContent[] = [
+    {
+      type: "paragraph",
+      children: [{ type: "text", value: `Network mocking: ${method}` }],
+    },
+  ];
+
+  return segment;
+};

--- a/packages/builder/src/project/__snapshots__/projectSegment.spec.ts.snap
+++ b/packages/builder/src/project/__snapshots__/projectSegment.spec.ts.snap
@@ -46,20 +46,6 @@ exports[`projectSegment > e2e project returns e2e rules 1`] = `
         ],
         "type": "listItem",
       },
-      {
-        "children": [
-          {
-            "children": [
-              {
-                "type": "text",
-                "value": "Use msw (Mock Service Worker) for API mocking in tests to ensure consistent and reliable test environments.",
-              },
-            ],
-            "type": "paragraph",
-          },
-        ],
-        "type": "listItem",
-      },
     ],
     "ordered": false,
     "type": "list",


### PR DESCRIPTION
## Summary
- add networkMocking segment to builder
- update CLI to pass networkMocking choice
- update builder options and snapshots
- add tests for new segment

## Testing
- `pnpm -r lint`
- `pnpm -r build`
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_6855de1501b48332b9149224cdd36e80