### PR TITLE
chore(cli): adopt eslint-config-agent (incremental, warn-level)

### DIFF
--- a/apps/cli/eslint.config.mjs
+++ b/apps/cli/eslint.config.mjs
@@ -1,0 +1,18 @@
+import recommendedIncremental from 'eslint-config-agent/recommended-incremental'
+
+export default [
+  ...recommendedIncremental,
+  {
+    // The build tsconfig excludes *.spec.ts (kept out of `tsc`'s emitted
+    // dist), so lint needs its own project that includes them, or every
+    // spec file fails to parse with "not found by the project service".
+    files: ['**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+        project: ['./tsconfig.eslint.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -10,7 +10,7 @@
     "build": "tsc",
     "prebuild": "rimraf dist",
     "start:cli": "node dist/main.js",
-    "lint": "tsc --noEmit",
+    "lint": "tsc --noEmit && eslint .",
     "test": "vitest run",
     "test:watch": "vitest watch"
   },
@@ -23,6 +23,8 @@
   "packageManager": "pnpm@10.12.1",
   "devDependencies": {
     "@types/node": "^24.0.1",
+    "eslint": "^9.39.4",
+    "eslint-config-agent": "^3.1.0",
     "rimraf": "^6.0.1",
     "typescript": "~5.1.6",
     "vitest": "^3.2.3"

--- a/apps/cli/tsconfig.eslint.json
+++ b/apps/cli/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": ["node_modules", "dist", "coverage"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,12 @@ importers:
       '@types/node':
         specifier: ^24.0.1
         version: 24.0.3
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.4.2)
+      eslint-config-agent:
+        specifier: ^3.1.0
+        version: 3.1.0(jiti@2.4.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(react@19.2.7))(typescript@5.1.6)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1


### PR DESCRIPTION
## Summary
- apps/cli had no ESLint setup (\`lint\` was just \`tsc --noEmit\`); adds \`eslint-config-agent/recommended-incremental\` matching the config \`packages/builder\` already uses in this monorepo
- Adds \`eslint\` + \`eslint-config-agent\` devDeps, an \`eslint.config.mjs\`, and a \`tsconfig.eslint.json\` (same pattern as builder, needed so \`.spec.ts\` files parse)
- \`lint\` script now runs \`tsc --noEmit && eslint .\`

Warn-level preset keeps CI green (0 errors, 86 warnings) while surfacing the full backlog to burn down incrementally. No source files changed.

Closes #55

## Test plan
- [x] \`pnpm install\`
- [x] \`pnpm --filter @vibe-builder/cli lint\` → 0 errors, 86 warnings
- [x] \`pnpm --filter @vibe-builder/cli build\` → passes
- [x] \`pnpm --filter @vibe-builder/cli test\` → 21 passed