### PR TITLE
Add block-no-verify Claude Code hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm exec block-no-verify"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__github__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm exec block-no-verify"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "turbo test"
   },
   "devDependencies": {
+    "block-no-verify": "^1.3.0",
     "turbo": "^2.5.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      block-no-verify:
+        specifier: ^1.3.0
+        version: 1.3.0
       turbo:
         specifier: ^2.5.5
         version: 2.5.5
@@ -800,6 +803,10 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@polyhook/sdk@0.1.11':
+    resolution: {integrity: sha512-Tb8NJ6oYxEwWAlsC0R/PFDIxMjYyXsZQOwSjoMD0eEPppyf1BtNfcZO1oSXxM2eQsEynlpOXr6cDku9B7KUSSQ==}
+    engines: {node: '>=18'}
+
   '@rollup/rollup-android-arm-eabi@4.43.0':
     resolution: {integrity: sha512-Krjy9awJl6rKbruhQDgivNbD1WuLb8xAclM4IR4cN5pHGAs2oIMMQJEiC3IC/9TZJ+QZkmZhlMO/6MBGxPidpw==}
     cpu: [arm]
@@ -1344,6 +1351,11 @@ packages:
 
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
+
+  block-no-verify@1.3.0:
+    resolution: {integrity: sha512-pUEt/KwRe2Uu5abvSZwaA8J6FCcNqjy+IebPW6DAgag81NmqUnCxd63ueivAa8L3f1bYL0dMXJ9WgJ2uyg1ZvA==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
 
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
@@ -4109,6 +4121,8 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@polyhook/sdk@0.1.11': {}
+
   '@rollup/rollup-android-arm-eabi@4.43.0':
     optional: true
 
@@ -4660,6 +4674,10 @@ snapshots:
   basic-ftp@5.0.5: {}
 
   before-after-hook@3.0.2: {}
+
+  block-no-verify@1.3.0:
+    dependencies:
+      '@polyhook/sdk': 0.1.11
 
   brace-expansion@1.1.15:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` wiring [block-no-verify](https://www.npmjs.com/package/block-no-verify) as a `PreToolUse` hook, blocking `--no-verify`, `core.hooksPath` overrides, and GitHub MCP writes that bypass local git hooks.
- Adds `block-no-verify` as a devDependency (pinned `^1.3.0`) so `pnpm exec block-no-verify` resolves consistently, per the package's documented Claude Code integration.

## Test plan
- [x] Verified `.claude/settings.json` matches the package README's documented Claude Code hook config
- [x] `pnpm install --lockfile-only` run to keep lockfile in sync with the new devDependency

Generated with Claude Code