### PR TITLE
docs: add cross-link to related project moadim.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ This repository uses [Turborepo](https://turbo.build) for managing tasks across 
 - `pnpm build` - run build in all packages
 - `pnpm lint` - run type checking
 - `pnpm test` - run unit tests
+
+## See also
+
+- [moadim](https://moadim.io/) - loop engineering: build, schedule & run agent loops.


### PR DESCRIPTION
Adds a reference/link to https://moadim.io (a related project by the same owner) under a new "See also" section in the README.

Owner-initiated cross-promotion between two of my own projects — no behavior change.