### PR TITLE
chore: add missing changesets (17 PRs)

### DIFF
--- a/.changeset/add-e2e-project-type.md
+++ b/.changeset/add-e2e-project-type.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/builder": minor
+---
+
+Add e2e project type support (Cypress, Playwright) (#43)

--- a/.changeset/add-e2epreferences-cli-segment.md
+++ b/.changeset/add-e2epreferences-cli-segment.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/cli": minor
+---
+
+Add e2ePreferences CLI segment (#51)

--- a/.changeset/add-general-ui-rules.md
+++ b/.changeset/add-general-ui-rules.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/builder": minor
+---
+
+Add general UI rules (#49)

--- a/.changeset/add-monorepo-system-support-to-builder.md
+++ b/.changeset/add-monorepo-system-support-to-builder.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/builder": minor
+---
+
+Add monorepo system support to builder (#27)

--- a/.changeset/add-network-mocking-to-builder.md
+++ b/.changeset/add-network-mocking-to-builder.md
@@ -1,0 +1,6 @@
+---
+"@vibe-builder/builder": minor
+"@vibe-builder/cli": minor
+---
+
+Add network mocking support to builder (#52)

--- a/.changeset/add-skip-option-for-release-system.md
+++ b/.changeset/add-skip-option-for-release-system.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/cli": minor
+---
+
+Add skip option for release system selection (#32)

--- a/.changeset/add-testing-framework-selection.md
+++ b/.changeset/add-testing-framework-selection.md
@@ -1,0 +1,6 @@
+---
+"@vibe-builder/builder": minor
+"@vibe-builder/cli": minor
+---
+
+Add testing framework selection (Jest, Mocha, Vitest) (#44)

--- a/.changeset/add-timestamp-option-to-cli.md
+++ b/.changeset/add-timestamp-option-to-cli.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/cli": minor
+---
+
+Add createdAt timestamp option to CLI (#39)

--- a/.changeset/add-turborepo-setup.md
+++ b/.changeset/add-turborepo-setup.md
@@ -1,0 +1,6 @@
+---
+"@vibe-builder/builder": patch
+"@vibe-builder/cli": patch
+---
+
+Integrate Turborepo build pipeline (#26)

--- a/.changeset/implement-cicd-segment.md
+++ b/.changeset/implement-cicd-segment.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/builder": minor
+---
+
+Implement CI/CD segment (#38)

--- a/.changeset/implement-createdat-timestamp-option.md
+++ b/.changeset/implement-createdat-timestamp-option.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/builder": minor
+---
+
+Implement createdAt timestamp option in builder (#37)

--- a/.changeset/implement-default-cicd-rules.md
+++ b/.changeset/implement-default-cicd-rules.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/builder": minor
+---
+
+Implement default CI/CD rules (#42)

--- a/.changeset/implement-monorepo-selection.md
+++ b/.changeset/implement-monorepo-selection.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/cli": minor
+---
+
+Implement monorepo selection prompt in CLI (#35)

--- a/.changeset/implement-skip-option-for-project-type.md
+++ b/.changeset/implement-skip-option-for-project-type.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/cli": minor
+---
+
+Implement skip option for project type selection (#41)

--- a/.changeset/implement-skip-positioning.md
+++ b/.changeset/implement-skip-positioning.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/cli": patch
+---
+
+Move "Skip" option to the end of CLI prompt choice lists (#29)

--- a/.changeset/implement-skip-step-option-in-cli.md
+++ b/.changeset/implement-skip-step-option-in-cli.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/cli": minor
+---
+
+Implement skip-step option in CLI (#24)

--- a/.changeset/update-cli-options-to-remove-none-when-skip-is-present.md
+++ b/.changeset/update-cli-options-to-remove-none-when-skip-is-present.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/cli": patch
+---
+
+Update CLI options to remove "None" from choice lists when a "Skip" option is present (#46)


### PR DESCRIPTION
Backfills changesets for all user-facing PRs merged since the last tag `v0.1.1-1` (2025-06-16) — the repo never adopted Changesets until now (see #59), so this covers the full gap in one pass.

Covered PRs:
- #52 Add network mocking to builder
- #51 Add e2ePreferences CLI segment
- #49 Add general UI rules
- #46 Update CLI options to remove None when Skip is present
- #44 Add testing framework selection
- #43 Add e2e project type
- #42 Implement default CICD rules
- #41 Implement skip option for project type
- #39 Add timestamp option to CLI
- #38 Implement CI/CD segment
- #37 Implement createdAt timestamp option
- #35 Implement monorepo selection
- #32 Add skip option for release system
- #29 Implement skip positioning
- #27 Add monorepo system support to builder
- #26 Add turborepo setup
- #24 Implement skip-step option in CLI

Depends on #59 landing first (adds `.changeset/config.json`), but is otherwise an independent branch off `main`.