### PR TITLE
chore: add missing changesets

### DIFF
--- a/.changeset/add-release-system-prompt-test.md
+++ b/.changeset/add-release-system-prompt-test.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/cli": patch
+---
+
+Add release system prompt test coverage (#31)

--- a/.changeset/add-release-system-selection.md
+++ b/.changeset/add-release-system-selection.md
@@ -1,0 +1,6 @@
+---
+"@vibe-builder/cli": minor
+"@vibe-builder/builder": patch
+---
+
+Add release system selection (#23)

--- a/.changeset/align-cli-repo-guidelines.md
+++ b/.changeset/align-cli-repo-guidelines.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/cli": patch
+---
+
+Align CLI with repository framework/testing guidelines (#50)

--- a/.changeset/cli-testing-framework-getter.md
+++ b/.changeset/cli-testing-framework-getter.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/cli": patch
+---
+
+Complete CLI testing-framework getter (#48)

--- a/.changeset/convert-builder-rules-typescript.md
+++ b/.changeset/convert-builder-rules-typescript.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/builder": patch
+---
+
+Convert builder rules to TypeScript (#16)

--- a/.changeset/convert-general-json-typed-rules.md
+++ b/.changeset/convert-general-json-typed-rules.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/builder": patch
+---
+
+Convert general JSON config to typed rules (#7)

--- a/.changeset/convert-pnpm-monorepo.md
+++ b/.changeset/convert-pnpm-monorepo.md
@@ -1,0 +1,6 @@
+---
+"@vibe-builder/builder": patch
+"@vibe-builder/cli": patch
+---
+
+Convert repo to a pnpm monorepo (#17)

--- a/.changeset/fix-cli-packaging.md
+++ b/.changeset/fix-cli-packaging.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/cli": patch
+---
+
+Fix CLI packaging (#4)

--- a/.changeset/fix-lint-and-build.md
+++ b/.changeset/fix-lint-and-build.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/builder": patch
+---
+
+Fix lint and build issues (#12)

--- a/.changeset/implement-lint-selection.md
+++ b/.changeset/implement-lint-selection.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/builder": minor
+---
+
+Implement lint system selection (#14)

--- a/.changeset/move-builder-under-packages.md
+++ b/.changeset/move-builder-under-packages.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/builder": patch
+---
+
+Move builder package under packages/ (#19)

--- a/.changeset/move-cli-to-apps.md
+++ b/.changeset/move-cli-to-apps.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/cli": patch
+---
+
+Move CLI to apps/ folder (#21)

--- a/.changeset/project-options-snapshot-fixes.md
+++ b/.changeset/project-options-snapshot-fixes.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/builder": patch
+---
+
+Add project options and fix related snapshots (#33)

--- a/.changeset/publishable-builder-package.md
+++ b/.changeset/publishable-builder-package.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/builder": minor
+---
+
+Make the builder package publishable (#2)

--- a/.changeset/refactor-get-project-type.md
+++ b/.changeset/refactor-get-project-type.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/cli": patch
+---
+
+Refactor getProjectType with tests (#25)

--- a/.changeset/remove-cli-test-folder.md
+++ b/.changeset/remove-cli-test-folder.md
@@ -1,0 +1,5 @@
+---
+"@vibe-builder/cli": patch
+---
+
+Remove redundant CLI test folder (#47)

--- a/.changeset/remove-spec-files-from-build.md
+++ b/.changeset/remove-spec-files-from-build.md
@@ -1,0 +1,6 @@
+---
+"@vibe-builder/builder": patch
+"@vibe-builder/cli": patch
+---
+
+Remove spec files from build output (#28)


### PR DESCRIPTION
Backfills `.changeset/*.md` for merged PRs not covered by the prior backfill (#60) or the initial batch.

## Covered
#2, #4, #7, #12, #14, #16, #17, #19, #21, #23, #25, #28, #31, #33, #47, #48, #50

## Excluded
CI-workflow-only PRs with no package changes (#8, #11, #13, #18, #22, #30, #34), and #20 (superseded by #21, identical diff).

No CHANGELOG.md edits — generated separately by `changeset version`.