### PR TITLE
docs: fix validation findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository is a collection of Agents coding prompts for better vibe coding 
 To use the prompts you have two options:
 
 1. **Copy and paste** the prompts from the files in this repository into your coding agent.
-2. **Generate the AGENTS.md file** by cloning this repository and running the `sh merge.sh` script. This will create a single `AGENTS.md` file that contains all the prompts from the individual files.
+2. **Generate the AGENTS.md file** by running the CLI: `npx @vibe-builder/cli`. It walks you through selecting your language, project type, and tooling, then writes a consolidated `AGENTS.md` file for you.
 
 ## Development
 


### PR DESCRIPTION
README.md:12 — Usage step 2 told readers to run `sh merge.sh` to generate AGENTS.md, but merge.sh does not exist anywhere in the repo (not in history, not referenced by CI/Makefile) — replaced with the actual mechanism: running the published CLI (`npx @vibe-builder/cli`, bin `vibe-builder`), which prompts for options and writes AGENTS.md via apps/cli/src/main.ts.